### PR TITLE
build: remove stale Alleycat main refresh

### DIFF
--- a/.github/dist-build-setup.yml
+++ b/.github/dist-build-setup.yml
@@ -29,7 +29,3 @@
 
 - name: Install sccache
   uses: mozilla-actions/sccache-action@v0.0.11
-
-- name: Resolve Alleycat to latest main
-  shell: bash
-  run: ./tools/scripts/update-alleycat-main.sh --kittylitter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,9 +160,6 @@ jobs:
       - name: "Install sccache"
         if: steps.sccache-config.outputs.enabled == 'true'
         uses: "mozilla-actions/sccache-action@v0.0.11"
-      - name: "Resolve Alleycat to latest main"
-        run: "./tools/scripts/update-alleycat-main.sh --kittylitter"
-        shell: "bash"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,6 @@ ifeq ($(firstword $(MAKECMDGOALS)),kittylitter)
 	@:
 endif
 KITTYLITTER_ARGS := $(strip $(KITTYLITTER_GOAL_ARGS) $(ARGS))
-UPDATE_ALLEYCAT_MAIN := $(ROOT)/tools/scripts/update-alleycat-main.sh
 
 PATCH_FILES := $(sort $(wildcard $(PATCHES_DIR)/*.patch))
 
@@ -220,7 +219,6 @@ $(shell mkdir -p $(STAMPS))
 	ios-xcode-sim ios-xcode-sim-fast ios-xcode-device ios-xcode-device-fast \
 	android-alpine-fs proot-android \
 	ghostty-ios ghostty-android \
-	alleycat-main \
 	bindings bindings-swift bindings-kotlin \
 	sync patch unpatch sync-ghostty unpatch-ghostty xcgen alpine-fs \
 	ios-build ios-build-sim ios-build-sim-fast ios-build-device ios-build-device-fast \
@@ -434,44 +432,41 @@ android-release: android-alpine-fs proot-android
 
 rust-ios: rust-ios-package
 
-alleycat-main:
-	@$(UPDATE_ALLEYCAT_MAIN) --all
-
-rust-ios-package: alleycat-main $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
+rust-ios-package: $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
 	@echo "==> Packaging Rust for iOS (device + simulator + xcframework)..."
 	@cd $(ROOT) && $(PACKAGE_CARGO_ENV) $(IOS_SCRIPTS)/build-rust.sh --preserve-current $(CARGO_FEATURES)
 	@$(mark_swift_bindings_current)
 
-rust-ios-device-release: alleycat-main $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
+rust-ios-device-release: $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
 	@echo "==> Building Rust for iOS release archive prep (device staticlib + headers)..."
 	@cd $(ROOT) && $(PACKAGE_CARGO_ENV) $(IOS_SCRIPTS)/build-rust.sh --preserve-current --device-only $(CARGO_FEATURES)
 	@$(mark_swift_bindings_current)
 
-rust-mac-release: alleycat-main $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
+rust-mac-release: $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
 	@echo "==> Building Rust for Mac Catalyst release archive prep (macabi staticlib + headers)..."
 	@cd $(ROOT) && $(PACKAGE_CARGO_ENV) $(IOS_SCRIPTS)/build-rust.sh --preserve-current --macabi-only $(CARGO_FEATURES)
 	@$(mark_swift_bindings_current)
 
-rust-ios-device-fast: alleycat-main $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
+rust-ios-device-fast: $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
 	@echo "==> Building Rust for fast iOS device iteration (raw staticlib + headers)..."
 	@cd $(ROOT) && $(DEV_CARGO_ENV) $(IOS_SCRIPTS)/build-rust.sh --preserve-current --fast-device $(CARGO_FEATURES)
 	@$(mark_swift_bindings_current)
 
-rust-ios-sim-fast: alleycat-main $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
+rust-ios-sim-fast: $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
 	@echo "==> Building Rust for fast iOS simulator iteration (raw staticlib + headers)..."
 	@cd $(ROOT) && $(DEV_CARGO_ENV) $(IOS_SCRIPTS)/build-rust.sh --preserve-current --fast-sim $(CARGO_FEATURES)
 	@$(mark_swift_bindings_current)
 
-rust-ios-macabi-fast: alleycat-main $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
+rust-ios-macabi-fast: $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
 	@echo "==> Building Rust for fast Mac Catalyst iteration (raw macabi staticlib + headers, host arch only)..."
 	@cd $(ROOT) && $(DEV_CARGO_ENV) $(IOS_SCRIPTS)/build-rust.sh --preserve-current --fast-macabi $(CARGO_FEATURES)
 	@$(mark_swift_bindings_current)
 
-rust-check: alleycat-main $(STAMP_SYNC)
+rust-check: $(STAMP_SYNC)
 	@echo "==> cargo check (host, shared crates)..."
 	@cd $(ROOT) && $(DEV_CARGO_ENV) cargo check --manifest-path $(RUST_DIR)/Cargo.toml -p codex-mobile-client
 
-rust-test: alleycat-main $(STAMP_SYNC) rust-shellcheck
+rust-test: $(STAMP_SYNC) rust-shellcheck
 	@echo "==> cargo test (host, shared crates)..."
 	@cd $(ROOT) && $(DEV_CARGO_ENV) cargo test --manifest-path $(RUST_DIR)/Cargo.toml -p codex-mobile-client --lib
 
@@ -493,7 +488,7 @@ rust-shellcheck:
 rust-host-dev: rust-check rust-test
 
 rust-android: $(STAMP_RUST_ANDROID)
-$(STAMP_RUST_ANDROID): $(STAMP_SYNC) $(STAMP_BINDINGS_K) $(STAMP_GHOSTTY_ANDROID) $(ANDROID_RUST_SOURCES) tools/scripts/build-android-rust.sh Makefile | alleycat-main
+$(STAMP_RUST_ANDROID): $(STAMP_SYNC) $(STAMP_BINDINGS_K) $(STAMP_GHOSTTY_ANDROID) $(ANDROID_RUST_SOURCES) tools/scripts/build-android-rust.sh Makefile
 	@echo "==> Building Rust for Android..."
 	@cd $(ROOT) && $(ANDROID_ENV) ANDROID_ABIS="$(ANDROID_ABIS)" ANDROID_RUST_PROFILE="$(ANDROID_RUST_PROFILE)" $(DEV_CARGO_ENV) ./tools/scripts/build-android-rust.sh
 	@touch $@
@@ -545,7 +540,6 @@ help:
 		'make proot-android     build Android proot executable artifacts' \
 		'make ghostty-ios        build pinned Ghostty iOS renderer artifacts' \
 		'make ghostty-android    build pinned Ghostty Android renderer artifacts (requires Android platform patch)' \
-		'make alleycat-main      refresh unpinned Alleycat git deps to latest dnakov/alleycat main' \
 		'make catalyst           full Mac Catalyst build (release+LTO macabi staticlib + xcodebuild)' \
 		'make catalyst-run       full Mac Catalyst build + launch' \
 		'make catalyst-fast      fast Mac Catalyst dev build (ios-dev profile, host arch)' \
@@ -591,7 +585,7 @@ unpatch-ghostty:
 bindings: bindings-swift bindings-kotlin
 
 bindings-swift: $(STAMP_BINDINGS_S)
-$(STAMP_BINDINGS_S): $(STAMP_SYNC) $(BOUNDARY_SOURCES) | alleycat-main
+$(STAMP_BINDINGS_S): $(STAMP_SYNC) $(BOUNDARY_SOURCES)
 	@echo "==> Generating Swift bindings..."
 	@cd $(RUST_DIR) && $(DEV_CARGO_ENV) ./generate-bindings.sh --swift-only
 	@mkdir -p $(IOS_GENERATED)/Headers
@@ -602,7 +596,7 @@ $(STAMP_BINDINGS_S): $(STAMP_SYNC) $(BOUNDARY_SOURCES) | alleycat-main
 	@current_hash="$$($(UNIFFI_BINDINGS_HASH_SCRIPT))"; printf '%s\n' "$$current_hash" >"$@"
 
 bindings-kotlin: $(STAMP_BINDINGS_K)
-$(STAMP_BINDINGS_K): $(STAMP_SYNC) $(BOUNDARY_SOURCES) | alleycat-main
+$(STAMP_BINDINGS_K): $(STAMP_SYNC) $(BOUNDARY_SOURCES)
 	@echo "==> Generating Kotlin bindings..."
 	@cd $(RUST_DIR) && $(DEV_CARGO_ENV) ./generate-bindings.sh --kotlin-only
 	@touch $@
@@ -811,7 +805,7 @@ android-emulator-install: android-emulator-fast
 
 test: test-rust test-ios test-android
 
-test-rust: alleycat-main $(STAMP_SYNC)
+test-rust: $(STAMP_SYNC)
 	@echo "==> Running Rust tests..."
 	@cd $(ROOT) && $(DEV_CARGO_ENV) cargo test --manifest-path $(RUST_DIR)/Cargo.toml -p codex-mobile-client --lib
 

--- a/apps/ios/scripts/build-rust.sh
+++ b/apps/ios/scripts/build-rust.sh
@@ -143,8 +143,6 @@ if [ -z "${RUSTC_WRAPPER:-}" ] && [ "${CARGO_INCREMENTAL:-}" != "1" ] && command
   export RUSTC_WRAPPER="$sccache_path"
 fi
 
-"$REPO_DIR/tools/scripts/update-alleycat-main.sh" --shared
-
 # libghostty static libs + headers must exist before the Rust crate is
 # compiled (codex-mobile-client links against them). Build them on demand
 # when missing so this script is self-sufficient for CI workflows that

--- a/docs/REPOSITORY_AUDIT.md
+++ b/docs/REPOSITORY_AUDIT.md
@@ -103,9 +103,9 @@ The continuation also separated confirmed debt from deletion candidates:
 - `local_studio_realtime.rs` is a large cross-repository protocol contract, not
   dead code. Superseded SSH and realtime boundary wrappers require live mobile
   acceptance before any later removal.
-- `services/kittylitter` still publishes v0.3.6 metadata and a Windows help link
-  for the former repository owner. The release guard correctly rejects changing
-  that package after its tag; update it only with a coordinated version bump.
+- `services/kittylitter` had stale v0.3.6 metadata and a Windows help link for
+  the former repository owner. The release guard correctly required a
+  coordinated version bump; the follow-up updates that package to v0.3.7.
 
 ## Architecture conclusions
 

--- a/services/kittylitter/Cargo.lock
+++ b/services/kittylitter/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "kittylitter"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "alleycat",
  "anyhow",

--- a/services/kittylitter/Cargo.toml
+++ b/services/kittylitter/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "kittylitter"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 license = "GPL-3.0-only"
 authors = ["The Alleycat Authors"]

--- a/services/kittylitter/README.md
+++ b/services/kittylitter/README.md
@@ -6,7 +6,7 @@ The wrapper itself is a 3-line `main()` that re-exports `alleycat::run("kittylit
 
 ## Cutting a release
 
-1. Push the alleycat changes to `dnakov/alleycat`.
-2. Keep the `alleycat` dependency on `branch = "main"` and refresh it with `./tools/scripts/update-alleycat-main.sh --kittylitter`.
-3. Bump `version` in this crate's `Cargo.toml` and the version of the kittylitter binary tracking it.
-4. Tag `vX.Y.Z` on the litter repo. The `release.yml` workflow at the repo root builds and publishes.
+1. Land the Alleycat change in `dnakov/alleycat`, then choose the immutable commit to ship.
+2. Update the matching `rev` pins and lockfiles in `services/kittylitter` and `shared/rust-bridge`; the daemon and mobile bridge must ship the same Alleycat revision.
+3. Run the relevant mobile acceptance lanes, then bump `version` in this crate's `Cargo.toml` and the version of the kittylitter binary tracking it.
+4. Tag `vX.Y.Z` on the Litter repo. The root `release.yml` workflow builds and publishes from the pinned dependency graph.

--- a/services/kittylitter/README.md
+++ b/services/kittylitter/README.md
@@ -8,5 +8,5 @@ The wrapper itself is a 3-line `main()` that re-exports `alleycat::run("kittylit
 
 1. Land the Alleycat change in `dnakov/alleycat`, then choose the immutable commit to ship.
 2. Update the matching `rev` pins and lockfiles in `services/kittylitter` and `shared/rust-bridge`; the daemon and mobile bridge must ship the same Alleycat revision.
-3. Run the relevant mobile acceptance lanes, then bump `version` in this crate's `Cargo.toml` and the version of the kittylitter binary tracking it.
-4. Tag `vX.Y.Z` on the Litter repo. The root `release.yml` workflow builds and publishes from the pinned dependency graph.
+3. Run the relevant mobile acceptance lanes, then bump `version` in this crate's `Cargo.toml`.
+4. Land that version bump on `main`. The `auto-release` workflow dispatches `release.yml`, which creates the tag and publishes from the pinned dependency graph.

--- a/shared/rust-bridge/generate-bindings.sh
+++ b/shared/rust-bridge/generate-bindings.sh
@@ -25,8 +25,6 @@ if [[ -z "${RUSTC_WRAPPER:-}" ]] && [[ "${CARGO_INCREMENTAL:-}" != "1" ]] && com
     export RUSTC_WRAPPER="$sccache_path"
 fi
 
-"$WORKSPACE_DIR/../../tools/scripts/update-alleycat-main.sh" --shared
-
 PROFILE="debug"
 GENERATE_SWIFT=1
 GENERATE_KOTLIN=1

--- a/tools/scripts/build-android-rust.sh
+++ b/tools/scripts/build-android-rust.sh
@@ -49,8 +49,6 @@ fi
 echo "==> Preparing codex submodule..."
 "$SYNC_SCRIPT" --preserve-current
 
-"$REPO_DIR/tools/scripts/update-alleycat-main.sh" --shared
-
 ABI_INPUT="${ANDROID_ABIS:-$DEFAULT_ANDROID_ABIS}"
 ABI_INPUT="${ABI_INPUT//,/ }"
 read -r -a REQUESTED_ABIS <<<"$ABI_INPUT"


### PR DESCRIPTION
## Purpose

Remove the obsolete automatic “latest Alleycat main” refresh from build and release paths. Litter ships immutable Alleycat revision `417f2a9…`; the old script immediately detected that pin and did no work.

## Changes

- remove the no-op prerequisite/calls from Make, mobile scripts, and release CI
- retain `update-alleycat-main.sh` as an explicit operator tool
- document the immutable pin-and-validate release flow
- bump kittylitter to `0.3.7`, because its published `v0.3.6` source must remain immutable

## Verification

- `bash -n apps/ios/scripts/build-rust.sh tools/scripts/build-android-rust.sh shared/rust-bridge/generate-bindings.sh tools/scripts/update-alleycat-main.sh`
- `cargo check --locked --manifest-path services/kittylitter/Cargo.toml`
- `./tools/scripts/check-kittylitter-release-version.sh`
- `make rust-check`
- `git diff --check`

The release guard initially rejected the documentation change at `0.3.6`; the committed `0.3.7` metadata is deliberate and makes this a releasable package change.