### PR TITLE
v2.0.1 mega convergence

### DIFF
--- a/apps/android/app/src/debug/java/com/litter/android/state/DebugFixtures.kt
+++ b/apps/android/app/src/debug/java/com/litter/android/state/DebugFixtures.kt
@@ -1,0 +1,175 @@
+package com.litter.android.state
+import android.content.Intent
+import android.os.SystemClock
+import com.litter.android.util.LLog
+import kotlinx.coroutines.*
+import uniffi.codex_mobile_client.*
+/** W1 (perf-0b) DEBUG-only measurement seams — Android half of the iOS W1 #if DEBUG additions: deterministic production
+ * fixture (default 300 sessions / 1500 items, iOS six-case cycle), A-8 burst driver, A-1 ingress ring (512 + eviction), A-9 watchdog, A-10 beacon; debug source set only. */
+object DebugFixtures : AppModelDebugPerfHooks {
+    private const val TAG = "burst"; private const val EPOCH = 1_700_000_000L; private const val SERVER_ID = "fixture-server"
+    private const val LIVE_ASSISTANT_ITEM_ID = "fixture-live-assistant-1" // thread-1 only (foreign stream)
+    private const val BURST_ITEM_ID = "fixture-item-1" // assistant item on displayed thread-0
+    const val EXTRA_FIXTURE_SESSIONS = "litter.debug.fixtureSessions"; const val EXTRA_FIXTURE_ITEMS = "litter.debug.fixtureItems"
+    const val EXTRA_STREAM_FOREIGN_MS = "litter.debug.streamForeignMs"; const val EXTRA_BURST_TIMINGS_MS = "litter.debug.burstTimingsMs"; const val EXTRA_BURST_NONCE = "litter.debug.burstNonce"
+    const val T0_PROMPT = "Run the command sh -c 'for i in 1 2 3 4 5 6 7 8; do echo tick \$i; sleep 1; done' and then summarize its output in one sentence."
+    const val T0_LONG_PROMPT = "Run the command sh -c 'for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do echo tick \$i; sleep 1; done' and then summarize its output in one sentence."
+    val fixtureThreadKey = ThreadKey(SERVER_ID, "fixture-thread-0"); val liveThreadKey = ThreadKey(SERVER_ID, "fixture-thread-1")
+    private val INPUT_REGEX = Regex("^B([1-9][0-9]{0,2})\\.([1-9][0-9]?)-(PLAIN|STEER)-([0-9a-f]{6})$")
+    class BurstInput(val raw: String, val trial: String, val attempt: String, val steer: Boolean, val hex: String) { fun wire(k: Int) = "B$trial.$attempt-F$k-$hex" }
+    /** Pure grammar gate (Fable W1 amendment): absent ⇒ silent idle; no trim/case-fold/fallback. */
+    fun parseBurstInput(raw: String?): BurstInput? {
+        val raw = raw ?: return null; val g = INPUT_REGEX.matchEntire(raw)?.groupValues ?: return null
+        return BurstInput(raw, g[1], g[2], g[3] == "STEER", g[4])
+    }
+    fun rejectionLine(raw: String?, parsed: BurstInput? = parseBurstInput(raw)): String? = when { raw == null || parsed != null -> null; raw.isEmpty() -> "burst.driver reject reason=missing-nonce"; else -> "burst.driver reject reason=malformed-nonce value=\"$raw\"" } // absent/valid ⇒ null; bootstrap reuses its single parse
+    fun followUpTexts(input: BurstInput) = listOf(
+        "Follow-up one ${input.wire(1)}: reply with exactly ALPHA.",
+        "Follow-up two ${input.wire(2)}: reply with exactly " + (if (input.steer) "BRAVO-STEERED." else "BRAVO."),
+        "Follow-up three ${input.wire(3)}: reply with exactly CHARLIE.",
+    )
+    /** Exactly three positional fire offsets; each slot falls back to its own default when missing/invalid; clamped 10..2000 ms. */
+    fun parseTimings(raw: String?): List<Long> {
+        val slots = raw?.split(','); val defaults = listOf(200L, 400L, 700L)
+        return List(3) { i -> (slots?.getOrNull(i)?.trim()?.toLongOrNull() ?: defaults[i]).coerceIn(10L, 2_000L) }
+    }
+    fun burstPlan(offsetsMs: List<Long>, anchorMonoMs: Long): List<Pair<Int, Long>> = offsetsMs.mapIndexed { index, offset -> index to anchorMonoMs + offset }.sortedWith(compareBy({ it.second }, { it.first }))
+    /** One-shot evidence checkpoint: max(lastFire+1s, anchorWindow+8s); never polls queue state. */
+    fun checkpointDelayMs(offsetsMs: List<Long>, anchorIsLong: Boolean): Long = maxOf((offsetsMs.maxOrNull() ?: 0L) + 1_000L, (if (anchorIsLong) 20_000L else 8_000L) + 8_000L)
+    fun itemAt(i: Int) = HydratedConversationItem("fixture-item-$i", when (i % 6) {
+        0 -> HydratedConversationItemContent.User(HydratedUserMessageData("Fixture user message $i.", emptyList()))
+        1 -> HydratedConversationItemContent.Assistant(HydratedAssistantMessageData("Fixture assistant reply $i.", null, null, AppMessagePhase.FINAL_ANSWER))
+        2 -> HydratedConversationItemContent.Reasoning(HydratedReasoningData(listOf("Fixture reasoning $i."), emptyList()))
+        3 -> HydratedConversationItemContent.CommandExecution(HydratedCommandExecutionData("echo fixture-$i", "/Projects/Workspace-${i % 12}", AppOperationStatus.COMPLETED, "fixture output $i", 0, 120, null, emptyList()))
+        4 -> HydratedConversationItemContent.McpToolCall(HydratedMcpToolCallData("fixture-mcp", "fixtureTool", AppOperationStatus.COMPLETED, 80, "{}", "Fixture tool summary $i.", null, null, null, emptyList(), null))
+        else -> HydratedConversationItemContent.CommandExecution(HydratedCommandExecutionData("sleep ${i % 3 + 1}", "/Projects/Workspace-${i % 12}", AppOperationStatus.IN_PROGRESS, null, null, null, null, emptyList()))
+    }, "fixture-turn-${i / 6}", (i % 6).toUInt(), (EPOCH + i).toDouble(), i % 6 == 0)
+    private fun thread(i: Int, items: List<HydratedConversationItem>) = AppThreadSnapshot(
+        ThreadKey(SERVER_ID, "fixture-thread-$i"),
+        ThreadInfo("fixture-thread-$i", "Fixture thread $i", "gpt-fixture", ThreadSummaryStatus.IDLE, "Fixture preview $i", "/Projects/Workspace-${i / 25}", null, "openai", null, null, if (i > 0 && i % 10 == 9) "fixture-thread-${i - 9}" else null, null, null, EPOCH - i - 3_600L, EPOCH - i),
+        "codex", AppModeKind.DEFAULT, "gpt-fixture", null, null, null, items, emptyList(), null, null, null, null, null, null, null, null, null, null, null, true)
+    private fun summary(key: ThreadKey, updatedAt: Long, active: Boolean, parent: String? = null, title: String = "Fixture thread", preview: String = "Fixture preview", cwd: String = "/Projects/Workspace-0") = AppSessionSummary(key, "codex", "Fixture Studio", "fixture.local", title, preview, cwd, "gpt-fixture", "openai", parent, null, null, null, key.threadId, AppSubagentStatus.UNKNOWN, updatedAt, active, false, false, false, null, null, null, null, emptyList(), null, null, null, null, null)
+    fun makeSnapshot(sessions: Int, items: Int): AppSnapshotRecord {
+        val threads = (0 until maxOf(sessions, 2)).map { i ->
+            thread(i, when (i) {
+                0 -> (0 until maxOf(items, 0)).map(::itemAt)
+                1 -> listOf(
+                    HydratedConversationItem("fixture-live-user-1", HydratedConversationItemContent.User(HydratedUserMessageData("Fixture live turn.", emptyList())), "fixture-live-turn", 0u, (EPOCH + 10).toDouble(), true),
+                    HydratedConversationItem(LIVE_ASSISTANT_ITEM_ID, HydratedConversationItemContent.Assistant(HydratedAssistantMessageData("Fixture live stream.", null, null, AppMessagePhase.COMMENTARY)), "fixture-live-turn", 1u, (EPOCH + 11).toDouble(), false),
+                    HydratedConversationItem("fixture-live-assistant-2", HydratedConversationItemContent.Assistant(HydratedAssistantMessageData("Done.", null, null, AppMessagePhase.FINAL_ANSWER)), "fixture-live-turn", 2u, (EPOCH + 12).toDouble(), false))
+                else -> emptyList()
+            })
+        }
+        val server = AppServerSnapshot(SERVER_ID, "Fixture Studio", "fixture.local", 8390u, null, false, AppServerHealth.CONNECTED, AppServerTransportState.CONNECTED, AppServerCapabilities(true, true, true, true, false), null, false, null, emptyList(), null, listOf(AgentRuntimeInfo("codex", "codex", "Codex", true)), null, null)
+        return AppSnapshotRecord(listOf(server), threads, threads.map { summary(it.key, it.info.updatedAt ?: EPOCH, it.activeTurnId != null, it.info.parentThreadId, it.info.title ?: "", it.info.preview ?: "", it.info.cwd ?: "") }, 0uL, null, emptyList(), emptyList(), AppVoiceSessionSnapshot(null, null, null, null, emptyList(), null), emptyList(), null)
+    }
+    private fun burstState(key: ThreadKey, status: ThreadSummaryStatus, activeTurnId: String?, queued: List<AppQueuedFollowUpPreview>) = AppThreadStateRecord(key, ThreadInfo(key.threadId, "Fixture thread", "gpt-fixture", status, "Fixture preview", "/Projects/Workspace-0", null, "openai", null, null, null, null, null, EPOCH, EPOCH), "codex", AppModeKind.DEFAULT, "gpt-fixture", null, null, null, queued, activeTurnId, null, null, null, null, null, null, null, null, true)
+    /** Fixture-mode synthesized burst: queue grows per fire; the delta hits BURST_ITEM_ID on displayed thread-0. */
+    fun burstUpdates(index: Int, key: ThreadKey, texts: List<String>): List<AppStoreUpdateRecord> {
+        val queued = texts.take(index + 1).mapIndexed { j, text -> AppQueuedFollowUpPreview("fixture-burst-followup-$j", AppQueuedFollowUpKind.MESSAGE, text) }
+        return listOf(
+            AppStoreUpdateRecord.ThreadMetadataChanged(burstState(key, ThreadSummaryStatus.ACTIVE, "fixture-burst-turn", queued), summary(key, EPOCH, true), 0uL),
+            AppStoreUpdateRecord.ThreadStreamingDelta(key, BURST_ITEM_ID, ThreadStreamingDeltaKind.ASSISTANT_TEXT, " F${index + 1} burst δ"))
+    }
+    fun burstDrainUpdate(key: ThreadKey): AppStoreUpdateRecord = AppStoreUpdateRecord.ThreadMetadataChanged(burstState(key, ThreadSummaryStatus.IDLE, null, emptyList()), summary(key, EPOCH + 1, false), 0uL)
+    /** A-8 burst driver: one-shot IDLE→ARMED→FIRED latch anchored at the startTurn invocation instant. */
+    class BurstDriver(val offsetsMs: List<Long>, val input: BurstInput, val fixtureMode: Boolean) {
+        enum class Phase { IDLE, ARMED, FIRED }
+        var phase = Phase.IDLE; var anchorMonoMs = 0L; var anchorIsLong = false
+        private val followUps = followUpTexts(input)
+        fun arm() { if (phase == Phase.IDLE) phase = Phase.ARMED }
+        fun isFollowUpText(text: String) = followUps.contains(text); fun isAnchorPrompt(text: String) = text == T0_PROMPT || text == T0_LONG_PROMPT
+        fun onStartTurnEntered(text: String, nowMonoMs: Long): List<Pair<Int, Long>>? {
+            if (phase != Phase.ARMED || !isAnchorPrompt(text)) return null
+            phase = Phase.FIRED; anchorMonoMs = nowMonoMs; anchorIsLong = text == T0_LONG_PROMPT; return burstPlan(offsetsMs, nowMonoMs)
+        }
+    }
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default); private val ledger = ArrayDeque<String>(); private var droppedSinceFlush = 0
+    private var watchdogJob: Job? = null; private var foreignStreamJob: Job? = null; private var hookedModel: AppModel? = null; private var armedDriver: BurstDriver? = null
+    private fun monoMs() = SystemClock.uptimeMillis()
+    internal fun appendLedger(line: String) = synchronized(ledger) { // A-1 ring: cap 512, overwrite-on-full, evictions counted since last flush
+        ledger.addLast(line); if (ledger.size > 512) { ledger.removeFirst(); droppedSinceFlush++ }
+    }
+    /** LEDGER_FLUSH_LAW: emit header + captured entries first; clear exactly the emitted batch; never clear on emit failure. */
+    fun flushLedger(reason: String, emit: (String) -> Unit = { LLog.i(TAG, it) }) {
+        synchronized(ledger) {
+            val batch = ledger.toList(); val dropped = droppedSinceFlush; if (batch.isEmpty() && dropped == 0) return
+            try { emit("burst.ledger flush reason=$reason entries=${batch.size} dropped=$dropped"); batch.forEach(emit) } catch (_: Throwable) { return }
+            repeat(batch.size) { ledger.removeFirst() }; droppedSinceFlush = 0
+        }
+    }
+    /** A-1 post-apply ingress: mono + wall, variant, full ThreadKey, queued count, steer kinds, active turn, revision. */
+    override fun onStoreUpdateApplied(update: AppStoreUpdateRecord) {
+        var k: ThreadKey? = null; var queued: List<AppQueuedFollowUpPreview>? = null; var active: String? = null
+        when (update) {
+            is AppStoreUpdateRecord.ThreadUpserted -> { k = update.thread.key; queued = update.thread.queuedFollowUps; active = update.thread.activeTurnId }
+            is AppStoreUpdateRecord.ThreadMetadataChanged -> { k = update.state.key; queued = update.state.queuedFollowUps; active = update.state.activeTurnId }
+            is AppStoreUpdateRecord.ThreadItemChanged -> k = update.key; is AppStoreUpdateRecord.ThreadStreamingDelta -> k = update.key
+            is AppStoreUpdateRecord.DynamicWidgetStreaming -> k = update.key; is AppStoreUpdateRecord.ThreadRemoved -> k = update.key
+            is AppStoreUpdateRecord.ActiveThreadChanged -> k = update.key; else -> {}
+        }
+        if (queued == null && k != null) { val t = hookedModel?.debugCachedThreadSnapshot(k); queued = t?.queuedFollowUps; if (active == null) active = t?.activeTurnId }
+        appendLedger("burst.ingress mono=${monoMs()} wall=${System.currentTimeMillis()} variant=${update::class.simpleName} key=${k?.serverId ?: "-"}/${k?.threadId ?: "-"} queued=${queued?.size ?: "-"} steer=${steerKinds(queued)} activeTurn=${active ?: "-"} rev=${if (update is AppStoreUpdateRecord.ActiveThreadChanged || k == null) (hookedModel?.conversationGlobalRevision?.value ?: -1L) else (hookedModel?.threadRevision(k!!)?.value ?: -1L)}")
+    }
+    private fun steerKinds(p: List<AppQueuedFollowUpPreview>?) = "${p?.count { it.kind == AppQueuedFollowUpKind.MESSAGE } ?: "-"}/${p?.count { it.kind == AppQueuedFollowUpKind.PENDING_STEER } ?: "-"}/${p?.count { it.kind == AppQueuedFollowUpKind.RETRYING_STEER } ?: "-"}"
+    private fun startWatchdog() { // A-9: 250 ms heartbeat; gaps > 500 ms land in the ring (mono + wall)
+        if (watchdogJob != null) return
+        watchdogJob = scope.launch(Dispatchers.Main) { var last = monoMs(); while (isActive) { delay(250); val now = monoMs(); val gap = now - last; last = now; if (gap > 500) appendLedger("burst.watchdog gapMs=$gap mono=$now wall=${System.currentTimeMillis()}") } }
+    }
+    private fun startForeignStream(appModel: AppModel, cadenceMs: Long) { // foreign deltas stay on thread-1's live assistant item (apply seam, no RPC)
+        if (cadenceMs <= 0 || foreignStreamJob != null) return
+        foreignStreamJob = scope.launch { var n = 0; while (isActive) { delay(cadenceMs); n++; appModel.debugInjectStoreUpdate(AppStoreUpdateRecord.ThreadStreamingDelta(liveThreadKey, LIVE_ASSISTANT_ITEM_ID, ThreadStreamingDeltaKind.ASSISTANT_TEXT, " fδ$n")) } }
+    }
+    override fun onStartTurnEntered(key: ThreadKey, text: String) {
+        val d = armedDriver ?: return
+        if (d.phase == BurstDriver.Phase.FIRED && d.isFollowUpText(text)) LLog.i(TAG, "burst.driver follow-up entry (recursion-guarded)")
+        val plan = d.onStartTurnEntered(text, monoMs()) ?: return
+        LLog.i(TAG, "burst.driver armed->fired anchorMonoMs=${d.anchorMonoMs} key=${key.serverId}/${key.threadId} wall=${System.currentTimeMillis()}")
+        scheduleFires(hookedModel ?: return, d, key, plan)
+    }
+    override fun onFlushLedger(reason: String) = flushLedger(reason)
+    private fun scheduleFires(appModel: AppModel, driver: BurstDriver, key: ThreadKey, plan: List<Pair<Int, Long>>) {
+        val texts = followUpTexts(driver.input)
+        val firesJob = if (driver.fixtureMode) scope.launch {
+            plan.forEach { (index, intended) -> // serialized canonical order: intended timestamp, then index
+                delay((intended - monoMs()).coerceAtLeast(0L)); val actual = monoMs()
+                LLog.i(TAG, "burst.driver fire F${index + 1} intended=$intended actual=$actual drift=${actual - intended} nonce=${driver.input.wire(index + 1)} wall=${System.currentTimeMillis()}")
+                appModel.debugBeaconVisibleUntilMs = monoMs() + 66
+                burstUpdates(index, key, texts).forEach { appModel.debugInjectStoreUpdate(it) }
+            }
+        } else null
+        if (!driver.fixtureMode) for ((index, intended) in plan) scope.launch { // live: independent per-fire Jobs
+            delay((intended - driver.anchorMonoMs).coerceAtLeast(0L)); val actual = monoMs()
+            LLog.i(TAG, "burst.driver fire F${index + 1} intended=$intended actual=$actual drift=${actual - intended} nonce=${driver.input.wire(index + 1)} wall=${System.currentTimeMillis()}")
+            appModel.debugBeaconVisibleUntilMs = monoMs() + 66
+            appModel.startTurn(key, AppComposerPayload(text = texts[index]))
+        }
+        if (driver.fixtureMode) scope.launch {
+            delay((driver.anchorMonoMs + (if (driver.anchorIsLong) 20_000L else 8_000L) + 500L - monoMs()).coerceAtLeast(0L)); firesJob?.join() // T0 window completion, then drain
+            LLog.i(TAG, "burst.t0Completed mono=${monoMs()} wall=${System.currentTimeMillis()}")
+            appModel.debugInjectStoreUpdate(burstDrainUpdate(key))
+        }
+        val cp = checkpointDelayMs(driver.offsetsMs, driver.anchorIsLong); scope.launch { delay(cp); flushLedger("checkpoint"); LLog.i(TAG, "burst.driver checkpoint delayMs=$cp wall=${System.currentTimeMillis()}") }
+    }
+    /** W1 entry point; reflectively called by MainActivity in DEBUG builds. True ⇒ fixture mode owns the snapshot; the armed driver waits for the real startTurn T0/T0_LONG anchor hook (startTurn returns before any RPC). */
+    @JvmStatic
+    fun bootstrap(intent: Intent, appModel: AppModel): Boolean {
+        val sessions = intent.getIntExtra(EXTRA_FIXTURE_SESSIONS, -1); val items = intent.getIntExtra(EXTRA_FIXTURE_ITEMS, -1)
+        val fixtureRequested = sessions >= 0 || items >= 0; val rawNonce = intent.getStringExtra(EXTRA_BURST_NONCE)
+        hookedModel = appModel; appModel.debugInstallPerfHooks(this)
+        val input = parseBurstInput(rawNonce)
+        rejectionLine(rawNonce, input)?.let { LLog.i(TAG, it) }
+        input?.let { inp ->
+            BurstDriver(parseTimings(intent.getStringExtra(EXTRA_BURST_TIMINGS_MS)), inp, fixtureRequested).also { d ->
+                d.arm(); armedDriver = d
+                LLog.i(TAG, "burst.driver idle->armed offsets=${d.offsetsMs.joinToString(",")} input=${inp.raw} trial=${inp.trial} attempt=${inp.attempt} steer=${if (inp.steer) "STEER" else "PLAIN"} hex=${inp.hex} mode=${if (fixtureRequested) "fixture" else "live"}")
+            }
+        }
+        if (fixtureRequested) {
+            appModel.debugApplyFixtureSnapshot(makeSnapshot(if (sessions >= 0) sessions else 300, if (items >= 0) items else 1500))
+            startForeignStream(appModel, intent.getStringExtra(EXTRA_STREAM_FOREIGN_MS)?.let { raw -> if (raw == "1") 100L else raw.toLongOrNull() ?: 100L } ?: 0L)
+        }
+        startWatchdog()
+        return fixtureRequested
+    }
+}

--- a/apps/android/app/src/main/java/com/litter/android/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/litter/android/MainActivity.kt
@@ -11,16 +11,21 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import com.google.firebase.FirebaseApp
@@ -35,6 +40,7 @@ import com.litter.android.ui.LitterApp
 import com.litter.android.ui.LitterAppTheme
 import com.litter.android.ui.WallpaperManager
 import com.litter.android.util.LLog
+import com.sigkitten.litter.android.BuildConfig
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import uniffi.codex_mobile_client.ThreadKey
@@ -72,7 +78,12 @@ class MainActivity : ComponentActivity() {
         try {
             appModel = AppModel.init(this)
             WallpaperManager.initialize(this)
+            if (BuildConfig.DEBUG && appModel?.debugPerfBootstrap(intent) == true) {
+                // W1 fixture/burst mode: the deterministic DEBUG fixture owns the
+                // snapshot; the production Rust/store subscription is skipped.
+            } else {
             appModel?.start()
+            }
         } catch (e: Exception) {
             LLog.e("MainActivity", "AppModel.start() failed", e)
         }
@@ -126,6 +137,9 @@ class MainActivity : ComponentActivity() {
                     ) {
                         AnimatedSplashScreen()
                     }
+
+                    // A-10 beacon: 20 ms poll is disclosed Debug-venue measurement overhead.
+                    if (BuildConfig.DEBUG && model != null) DebugBurstBeaconOverlay(model)
                 }
             }
         }
@@ -147,6 +161,12 @@ class MainActivity : ComponentActivity() {
         super.onPause()
         val model = appModel ?: return
         lifecycleController.onPause(this, model)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        // W1 LEDGER_FLUSH_LAW backstop: DEBUG lifecycle flush persists the post-settle tail.
+        if (BuildConfig.DEBUG) appModel?.debugFlushPerfLedger("on-stop")
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -255,6 +275,21 @@ class MainActivity : ComponentActivity() {
         notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
     }
 
+}
+
+// W1: single reflective bridge into the debug source set (src/debug); absent and inert in release builds.
+private fun AppModel.debugPerfBootstrap(intent: Intent): Boolean = runCatching {
+    Class.forName("com.litter.android.state.DebugFixtures")
+        .getDeclaredMethod("bootstrap", Intent::class.java, AppModel::class.java)
+        .invoke(null, intent, this) as? Boolean ?: false
+}.getOrDefault(false)
+
+// W1 A-10 burst beacon: DEBUG-only 20 ms poll; layout-only, hit-test transparent.
+@Composable
+private fun DebugBurstBeaconOverlay(appModel: AppModel) {
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(appModel) { while (true) { delay(20); visible = appModel.debugBeaconVisible } }
+    if (visible) Text(text = "◼◼", color = Color.White, fontSize = 30.sp, modifier = Modifier.padding(6.dp).background(Color.Black))
 }
 
 internal fun shouldRequestNotificationPermission(

--- a/apps/android/app/src/main/java/com/litter/android/state/AppModel.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/AppModel.kt
@@ -1,6 +1,8 @@
 package com.litter.android.state
 
+import android.os.SystemClock
 import com.litter.android.core.bridge.UniffiInit
+import com.sigkitten.litter.android.BuildConfig
 import com.litter.android.util.LLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -332,6 +334,7 @@ class AppModel private constructor(context: android.content.Context) {
     // --- Snapshot refresh -----------------------------------------------------
 
     suspend fun refreshSnapshot() {
+        if (BuildConfig.DEBUG && debugFixtureActive) return
         try {
             val snap = store.snapshot()
             applySnapshot(snap)
@@ -765,6 +768,7 @@ class AppModel private constructor(context: android.content.Context) {
         key: ThreadKey,
         payload: AppComposerPayload,
     ) {
+        if (BuildConfig.DEBUG) { debugPerfHooks?.onStartTurnEntered(key, payload.text); if (debugFixtureActive) return }
         restoreStoredLocalAuthIfNeeded(key.serverId, reason = "startTurn")
 
         try {
@@ -1038,7 +1042,8 @@ class AppModel private constructor(context: android.content.Context) {
     // --- Internal event handling ----------------------------------------------
 
     private suspend fun handleUpdate(update: AppStoreUpdateRecord) {
-        when (update) {
+        val tracing = BuildConfig.DEBUG && runCatching { android.os.Trace.beginSection("AppModel.handleUpdate"); true }.getOrDefault(false)
+        try { when (update) {
             is AppStoreUpdateRecord.ThreadUpserted ->
                 applyThreadUpsert(update.thread, update.sessionSummary, update.agentDirectoryVersion)
             is AppStoreUpdateRecord.ThreadMetadataChanged ->
@@ -1096,6 +1101,8 @@ class AppModel private constructor(context: android.content.Context) {
                 applyStreamingWidget(update.key, update.itemId, update.widget)
             is AppStoreUpdateRecord.TerminalSessionsChanged -> refreshSnapshot()
         }
+        if (BuildConfig.DEBUG) debugPerfHooks?.onStoreUpdateApplied(update)
+        } finally { if (tracing) android.os.Trace.endSection() }
     }
 
     /// Mutate an in-flight widget bubble's data so the timeline WebView
@@ -1608,6 +1615,31 @@ class AppModel private constructor(context: android.content.Context) {
 
         return snapshot.copy(threads = mergedThreads)
     }
+
+    // --- W1 DEBUG perf seams (measurement-only; implementation lives in the debug source set) ---
+    @Volatile private var debugPerfHooks: AppModelDebugPerfHooks? = null
+    @Volatile var debugFixtureActive = false
+        private set
+    fun debugInstallPerfHooks(hooks: AppModelDebugPerfHooks?) { if (BuildConfig.DEBUG) debugPerfHooks = hooks }
+    /** Fixture apply seam: publishes the deterministic fixture snapshot without touching Rust. */
+    fun debugApplyFixtureSnapshot(snapshot: AppSnapshotRecord) {
+        if (!BuildConfig.DEBUG) return
+        debugFixtureActive = true; _snapshot.value = snapshot; rebindLedger.bumpGlobal(); snapshot.threads.forEach(::cacheThreadSnapshot)
+    }
+    /** Fixture apply seam: one store update through the real handleUpdate path. */
+    suspend fun debugInjectStoreUpdate(update: AppStoreUpdateRecord) { if (BuildConfig.DEBUG) handleUpdate(update) }
+    fun debugCachedThreadSnapshot(key: ThreadKey): AppThreadSnapshot? = if (BuildConfig.DEBUG) cachedThreadSnapshots[key] else null // O(1) ledger fallback; never threadSnapshot()'s linear scan
+    /** A-10 beacon window (DEBUG): ~66 ms blink polled by the MainActivity overlay. */
+    @Volatile var debugBeaconVisibleUntilMs = 0L
+    val debugBeaconVisible: Boolean get() = BuildConfig.DEBUG && SystemClock.uptimeMillis() < debugBeaconVisibleUntilMs
+    fun debugFlushPerfLedger(reason: String) { if (BuildConfig.DEBUG) debugPerfHooks?.onFlushLedger(reason) }
+}
+
+/** W1 measurement-only hooks; implemented by the debug source set, never installed in release builds. */
+interface AppModelDebugPerfHooks {
+    fun onStoreUpdateApplied(update: AppStoreUpdateRecord)
+    fun onStartTurnEntered(key: ThreadKey, text: String)
+    fun onFlushLedger(reason: String)
 }
 
 private fun registerBundledCliTools() {

--- a/apps/android/app/src/main/java/com/litter/android/state/AppModel.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/AppModel.kt
@@ -175,6 +175,10 @@ class AppModel private constructor(context: android.content.Context) {
     private val _snapshot = MutableStateFlow<AppSnapshotRecord?>(null)
     val snapshot: StateFlow<AppSnapshotRecord?> = _snapshot.asStateFlow()
 
+    private val rebindLedger = ThreadRevisionLedger()
+    fun threadRevision(key: ThreadKey): StateFlow<Long> = rebindLedger.threadRevision(key)
+    val conversationGlobalRevision: StateFlow<Long> get() = rebindLedger.conversationGlobalRevision
+
     private val _lastError = MutableStateFlow<String?>(null)
     val lastError: StateFlow<String?> = _lastError.asStateFlow()
     private val loadingModelServerIds = mutableSetOf<String>()
@@ -348,7 +352,9 @@ class AppModel private constructor(context: android.content.Context) {
         val merged = snapshot
             ?.let(::applySavedServerNames)
             ?.let(::mergeCachedThreadSnapshots)
+        val before = _snapshot.value
         _snapshot.value = merged
+        if (before != merged) rebindLedger.bumpGlobal()
         if (merged != null) {
             persistWakeMacs(merged)
             merged.threads.forEach(::cacheThreadSnapshot)
@@ -1057,6 +1063,7 @@ class AppModel private constructor(context: android.content.Context) {
                 removeThreadSnapshot(update.key, update.agentDirectoryVersion)
             is AppStoreUpdateRecord.ActiveThreadChanged -> {
                 updateActiveThread(update.key)
+                rebindLedger.bumpGlobal()
                 if (update.key != null && threadSnapshot(update.key) == null) {
                     refreshThreadSnapshot(update.key)
                 }
@@ -1552,6 +1559,7 @@ class AppModel private constructor(context: android.content.Context) {
             agentDirectoryVersion = agentDirectoryVersion ?: current.agentDirectoryVersion,
             activeThread = if (current.activeThread == key) null else current.activeThread,
         )
+        rebindLedger.bumpThread(key)
         if (clearCache) {
             cachedThreadSnapshots.remove(key)
         }
@@ -1573,7 +1581,9 @@ class AppModel private constructor(context: android.content.Context) {
     }
 
     private fun cacheThreadSnapshot(thread: AppThreadSnapshot) {
+        val changed = cachedThreadSnapshots[thread.key] != thread
         cachedThreadSnapshots[thread.key] = thread
+        if (changed) rebindLedger.bumpThread(thread.key)
     }
 
     private fun mergedThreadSnapshotPreservingHydratedItems(thread: AppThreadSnapshot): AppThreadSnapshot {

--- a/apps/android/app/src/main/java/com/litter/android/state/ThreadRevisionLedger.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/ThreadRevisionLedger.kt
@@ -1,0 +1,43 @@
+package com.litter.android.state
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import uniffi.codex_mobile_client.ThreadKey
+
+/**
+ * Per-thread conversation rebind ledger. Tracks a monotonic revision per
+ * [ThreadKey] plus a single global revision, so Compose can scope
+ * conversation-surface re-derivation to the visible thread and fall back
+ * to a global rebind for unkeyed updates (approvals, pending inputs,
+ * server/resync publishes).
+ *
+ * Entries are intentionally never removed: a Compose `remember`-cached
+ * [StateFlow] for a re-added thread must keep collecting the same instance
+ * or it would miss every later bump. Memory cost is one tiny flow per thread
+ * ever seen in-process.
+ *
+ * Pure Kotlin (no `android.*` / UniFFI / AppModel dependency) so it is
+ * plain-JVM-testable. [ThreadKey] is a UniFFI data class already used in
+ * plain-JVM unit tests (see `SnapshotExtensionsTest`).
+ */
+class ThreadRevisionLedger {
+    private val lock = Any()
+    private val threadFlows = mutableMapOf<ThreadKey, MutableStateFlow<Long>>()
+    private val globalFlow = MutableStateFlow(0L)
+
+    val conversationGlobalRevision: StateFlow<Long> get() = globalFlow
+
+    fun threadRevision(key: ThreadKey): StateFlow<Long> = synchronized(lock) {
+        threadFlows.getOrPut(key) { MutableStateFlow(0L) }
+    }
+
+    fun bumpThread(key: ThreadKey) {
+        synchronized(lock) {
+            threadFlows.getOrPut(key) { MutableStateFlow(0L) }.also { it.value += 1 }
+        }
+    }
+
+    fun bumpGlobal() {
+        synchronized(lock) { globalFlow.value += 1 }
+    }
+}

--- a/apps/android/app/src/main/java/com/litter/android/ui/LitterThemeManager.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/LitterThemeManager.kt
@@ -19,6 +19,8 @@ private const val APPEARANCE_MODE_KEY = "appearance_mode"
 private const val DARK_MODE_KEY = "dark_mode_enabled"
 private const val FONT_MONO_KEY = "font_family_mono"
 private const val FONT_FAMILY_KEY = "font_family"
+private const val DEFAULT_LIGHT_THEME_SLUG = "studio-light"
+private const val DEFAULT_DARK_THEME_SLUG = "studio-dark"
 
 enum class LitterAppearanceMode(
     val storageValue: String,
@@ -46,7 +48,7 @@ enum class LitterFontFamilyOption(
     val displayName: String,
 ) {
     BERKELEY_MONO("mono", "Berkeley Mono"),
-    CHATGPT("system", "ChatGPT (System)"),
+    CHATGPT("system", "System UI"),
     SYSTEM_MONO("system-mono", "System Mono"),
     SERIF("serif", "Reader Serif");
 
@@ -279,10 +281,10 @@ object LitterThemeManager {
         get() = themeIndex.filter { it.type == LitterColorThemeType.DARK }
 
     val selectedLightSlug: String
-        get() = preferences?.getString(SELECTED_LIGHT_THEME_KEY, null) ?: "codex-light"
+        get() = preferences?.getString(SELECTED_LIGHT_THEME_KEY, null) ?: DEFAULT_LIGHT_THEME_SLUG
 
     val selectedDarkSlug: String
-        get() = preferences?.getString(SELECTED_DARK_THEME_KEY, null) ?: "chatgpt-dark"
+        get() = preferences?.getString(SELECTED_DARK_THEME_KEY, null) ?: DEFAULT_DARK_THEME_SLUG
 
     private val preferences
         get() = appContext?.getSharedPreferences(UI_PREFERENCES_NAME, Context.MODE_PRIVATE)

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
@@ -84,6 +84,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.sp
@@ -1267,7 +1268,8 @@ private fun QueuedFollowUpsPreviewPanel(
             .fillMaxWidth()
             .padding(horizontal = 12.dp)
             .background(LitterTheme.codeBackground, RoundedCornerShape(14.dp))
-            .padding(horizontal = 12.dp, vertical = 10.dp),
+            .padding(horizontal = 12.dp, vertical = 10.dp)
+            .testTag("conversation.queuedFollowUps"),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -1296,9 +1298,10 @@ private fun QueuedFollowUpsPreviewPanel(
             )
         }
 
-        previews.forEach { preview ->
+        previews.forEachIndexed { index, preview ->
             QueuedFollowUpCard(
                 preview = preview,
+                index = index,
                 onSteer = onSteer,
                 onDelete = onDelete,
             )
@@ -1309,6 +1312,7 @@ private fun QueuedFollowUpsPreviewPanel(
 @Composable
 private fun QueuedFollowUpCard(
     preview: AppQueuedFollowUpPreview,
+    index: Int,
     onSteer: (AppQueuedFollowUpPreview) -> Unit,
     onDelete: (AppQueuedFollowUpPreview) -> Unit,
 ) {
@@ -1319,7 +1323,8 @@ private fun QueuedFollowUpCard(
             .fillMaxWidth()
             .border(1.dp, style.border, RoundedCornerShape(12.dp))
             .background(style.background, RoundedCornerShape(12.dp))
-            .padding(12.dp),
+            .padding(12.dp)
+            .testTag("conversation.queuedFollowUp-$index"),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
@@ -1365,13 +1370,14 @@ private fun QueuedFollowUpCard(
                 modifier = Modifier
                     .background(LitterTheme.surface.copy(alpha = 0.96f), RoundedCornerShape(999.dp))
                     .clickable { onSteer(preview) }
-                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                    .testTag("conversation.queuedFollowUp-$index.steer"),
             )
         }
 
         IconButton(
             onClick = { onDelete(preview) },
-            modifier = Modifier.size(30.dp),
+            modifier = Modifier.size(30.dp).testTag("conversation.queuedFollowUp-$index.delete"),
         ) {
             Icon(
                 Icons.Default.Close,

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
@@ -86,6 +86,7 @@ import uniffi.codex_mobile_client.HydratedConversationItemContent
 import uniffi.codex_mobile_client.AppRenameThreadRequest
 import uniffi.codex_mobile_client.PendingUserInputRequest
 import uniffi.codex_mobile_client.ThreadKey
+import com.sigkitten.litter.android.BuildConfig
 
 /**
  * Main conversation screen with turn grouping, scroll-to-bottom FAB,
@@ -324,6 +325,8 @@ fun ConversationScreen(
 
     // Pinned context: latest TODO progress + combined session diff summary
     val pinnedContext = remember(items) {
+        val tracing = BuildConfig.DEBUG && runCatching { android.os.Trace.beginSection("Conversation.PinnedContextParse"); true }.getOrDefault(false)
+        try {
         var todoProgress: String? = null
         val rawDiffSections = mutableListOf<SessionDiffSection>()
         for (i in items.indices.reversed()) {
@@ -370,6 +373,7 @@ fun ConversationScreen(
         } else {
             null
         }
+        } finally { if (tracing) android.os.Trace.endSection() }
     }
 
     // Auto-scroll state

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
@@ -126,7 +126,9 @@ fun ConversationScreen(
         }
     }
 
-    val thread = remember(snapshot, threadKey) {
+    val threadRevision by remember(threadKey) { appModel.threadRevision(threadKey) }.collectAsState()
+    val conversationGlobalRevision by appModel.conversationGlobalRevision.collectAsState()
+    val thread = remember(threadRevision, conversationGlobalRevision, threadKey) {
         appModel.threadSnapshot(threadKey)
     }
     val server = remember(snapshot, threadKey) {

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/SelectableConversationText.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/SelectableConversationText.kt
@@ -69,12 +69,24 @@ internal fun SelectableMarkdownText(
             LitterFontFamilyOption.SERIF -> android.graphics.Typeface.SERIF
         }
     }
+    val codeTypeface = remember(context, selectedFontFamily) {
+        if (selectedFontFamily == LitterFontFamilyOption.BERKELEY_MONO) {
+            runCatching {
+                androidx.core.content.res.ResourcesCompat.getFont(
+                    context,
+                    com.sigkitten.litter.android.R.font.berkeley_mono_regular,
+                )
+            }.getOrNull() ?: android.graphics.Typeface.MONOSPACE
+        } else {
+            android.graphics.Typeface.MONOSPACE
+        }
+    }
     val markdownTextSizePx = remember(context, resolvedTextSize, usePhysicalDpTextSize) {
         resolvedTextSize.toTextSizePx(context, usePhysicalDpTextSize)
     }
     val markwon = rememberConversationMarkwon(
         context = context,
-        typeface = typeface,
+        codeTypeface = codeTypeface,
         markdownTextSizePx = markdownTextSizePx,
         textColor = textColor,
     )
@@ -110,6 +122,7 @@ internal fun SelectableMarkdownText(
                 textColor = textColor,
                 textSizePx = markdownTextSizePx,
                 typeface = typeface,
+                codeTypeface = codeTypeface,
             )
             if (tv.tag != renderTag) {
                 tv.tag = renderTag
@@ -125,6 +138,7 @@ private data class MarkdownRenderTag(
     val textColor: Int,
     val textSizePx: Float,
     val typeface: android.graphics.Typeface?,
+    val codeTypeface: android.graphics.Typeface?,
 )
 
 internal fun configureSelectableMarkdownTextView(
@@ -148,6 +162,7 @@ internal fun configureSelectableMarkdownTextView(
     textView.movementMethod = LinkMovementMethod.getInstance()
     textView.setLinkTextColor(linkColor)
     textView.setTextIsSelectable(selectable)
+    textView.setLineSpacing(0f, 1.32f)
     textView.customSelectionActionModeCallback = if (selectable) {
         RunInTerminalSelectionMenu(textView)
     } else {
@@ -216,16 +231,20 @@ private class RunInTerminalSelectionMenu(
 @Composable
 private fun rememberConversationMarkwon(
     context: android.content.Context,
-    typeface: android.graphics.Typeface?,
+    codeTypeface: android.graphics.Typeface?,
     markdownTextSizePx: Float,
     textColor: Int,
-): Markwon = remember(context, typeface, markdownTextSizePx, textColor) {
+): Markwon = remember(context, codeTypeface, markdownTextSizePx, textColor) {
     try {
         val prism4j = Prism4j(com.litter.android.ui.Prism4jGrammarLocator())
         Markwon.builder(context)
             .usePlugin(object : AbstractMarkwonPlugin() {
                 override fun configureTheme(builder: MarkwonTheme.Builder) {
-                    typeface?.let { builder.codeTypeface(it) }
+                    codeTypeface?.let { builder.codeTypeface(it) }
+                    codeTypeface?.let { builder.codeBlockTypeface(it) }
+                    val codeTextSize = markdownTextSizePx.times(0.94f).toInt()
+                    builder.codeTextSize(codeTextSize)
+                    builder.codeBlockTextSize(codeTextSize)
                 }
             })
             .usePlugin(

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/TurnGrouping.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/TurnGrouping.kt
@@ -44,6 +44,7 @@ import com.litter.android.ui.LitterTextStyle
 import com.litter.android.ui.LitterTheme
 import com.litter.android.ui.LocalTextScale
 import com.litter.android.ui.scaled
+import com.sigkitten.litter.android.BuildConfig
 import uniffi.codex_mobile_client.AppOperationStatus
 import uniffi.codex_mobile_client.HydratedCommandActionKind
 import uniffi.codex_mobile_client.HydratedConversationItem
@@ -113,6 +114,8 @@ fun buildTranscriptTurns(
     isStreaming: Boolean,
     expandedRecentTurnCount: Int,
 ): List<TranscriptTurn> {
+    val tracing = BuildConfig.DEBUG && runCatching { android.os.Trace.beginSection("TurnGrouping.buildTranscriptTurns"); true }.getOrDefault(false)
+    try {
     if (items.isEmpty()) return emptyList()
 
     val groupedItems = mergeConsecutiveExplorationGroups(
@@ -131,6 +134,7 @@ fun buildTranscriptTurns(
             isCollapsedByDefault = index < collapseBoundary,
         )
     }
+    } finally { if (tracing) android.os.Trace.endSection() }
 }
 
 private fun groupItems(items: List<HydratedConversationItem>): List<List<HydratedConversationItem>> {

--- a/apps/android/app/src/main/java/com/litter/android/ui/home/HomeDashboardSupport.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/home/HomeDashboardSupport.kt
@@ -15,6 +15,7 @@ import uniffi.codex_mobile_client.AppServerSnapshot
 import uniffi.codex_mobile_client.AppSessionSummary
 import uniffi.codex_mobile_client.AppSnapshotRecord
 import uniffi.codex_mobile_client.ThreadKey
+import com.sigkitten.litter.android.BuildConfig
 
 /**
  * Lightweight projection of a thread for use in lineage breadcrumbs and
@@ -190,6 +191,8 @@ object HomeDashboardSupport {
         snapshot: AppSnapshotRecord,
         limit: Int = 10,
     ): List<AppSessionSummary> {
+        val tracing = BuildConfig.DEBUG && runCatching { android.os.Trace.beginSection("Home.RecentSessions"); true }.getOrDefault(false)
+        try {
         val connectedServerIds = snapshot.servers
             .filter { it.health == AppServerHealth.CONNECTED }
             .map { it.serverId }
@@ -201,6 +204,7 @@ object HomeDashboardSupport {
             .distinctBy { it.key.serverId to it.key.threadId }
             .sortedByDescending { it.updatedAt ?: 0L }
             .take(limit)
+        } finally { if (tracing) android.os.Trace.endSection() }
     }
 
     /**

--- a/apps/android/app/src/main/java/com/litter/android/ui/sessions/SessionsDerivation.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/sessions/SessionsDerivation.kt
@@ -3,6 +3,7 @@ package com.litter.android.ui.sessions
 import com.litter.android.ui.home.HomeDashboardSupport
 import uniffi.codex_mobile_client.AppSessionSummary
 import uniffi.codex_mobile_client.ThreadKey
+import com.sigkitten.litter.android.BuildConfig
 
 /**
  * Tree node for session fork relationships.
@@ -56,6 +57,8 @@ object SessionsDerivation {
         searchQuery: String = "",
         sortMode: WorkspaceSortMode = WorkspaceSortMode.RECENT,
     ): SessionsDerivedData {
+        val tracing = BuildConfig.DEBUG && runCatching { android.os.Trace.beginSection("Sessions.Derive"); true }.getOrDefault(false)
+        try {
         val uniqueSummaries = summaries.distinctBy { it.key.serverId to it.key.threadId }
         val totalCount = uniqueSummaries.size
         val allThreadKeys = uniqueSummaries.map { it.key }
@@ -161,6 +164,7 @@ object SessionsDerivation {
             workspaceGroupKeyByThreadKey = workspaceGroupKeyByThreadKey,
             parentByKey = parentByKey,
         )
+        } finally { if (tracing) android.os.Trace.endSection() }
     }
 
     fun workspaceGroupKey(summary: AppSessionSummary): String =

--- a/apps/android/app/src/test/java/com/litter/android/state/DebugFixturesTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/state/DebugFixturesTest.kt
@@ -1,0 +1,77 @@
+package com.litter.android.state
+
+import org.junit.Assert.*
+import org.junit.Test
+import uniffi.codex_mobile_client.*
+
+/** W1 (perf-0b) pure-function coverage: Fable golden vectors V1–V5 (exact wire texts), full rejection
+ * table + exact rejectionLine strings (null only for absent/valid), positional timings, both checkpoint
+ * windows, arm-gated one-shot T0/T0_LONG latch + recursion guard, deterministic 300/1500 fixture with
+ * the iOS six-case cycle + per-thread summaries, thread-0 burst vs thread-1 foreign routing, 512-ring. */
+class DebugFixturesTest {
+    private fun v(raw: String) = DebugFixtures.parseBurstInput(raw)!!
+    @Test fun goldenVectorsV1ThroughV5() {
+        assertEquals(listOf("Follow-up one B7.1-F1-9af3c2: reply with exactly ALPHA.", "Follow-up two B7.1-F2-9af3c2: reply with exactly BRAVO.", "Follow-up three B7.1-F3-9af3c2: reply with exactly CHARLIE."), DebugFixtures.followUpTexts(v("B7.1-PLAIN-9af3c2"))) // V1
+        assertEquals(listOf("Follow-up one B12.2-F1-00ffee: reply with exactly ALPHA.", "Follow-up two B12.2-F2-00ffee: reply with exactly BRAVO-STEERED.", "Follow-up three B12.2-F3-00ffee: reply with exactly CHARLIE."), DebugFixtures.followUpTexts(v("B12.2-STEER-00ffee"))) // V2
+        assertTrue(v("B901.1-STEER-0c0ffe").steer); assertFalse(v("B15.1-PLAIN-abc123").steer) // V3/V4: mode comes only from the input
+        val d2a = DebugFixtures.BurstDriver(DebugFixtures.parseTimings(null), v("B12.2-STEER-00ffee"), true); val d2b = DebugFixtures.BurstDriver(DebugFixtures.parseTimings(null), v("B12.2-STEER-00ffee"), true) // V5: two fresh parses/drivers
+        assertEquals(d2a.input.steer, d2b.input.steer); assertEquals(DebugFixtures.followUpTexts(d2a.input), DebugFixtures.followUpTexts(d2b.input))
+    }
+    @Test fun rejectionTableAndExactRejectLines() {
+        listOf("B7.1-F2-9af3c2", "B7.1-9af3c2", "B7.1-plain-9af3c2", "B7.1-Steer-9af3c2", "B7.1-PLAIN-9AF3C2", "b7.1-PLAIN-9af3c2", "B07.1-PLAIN-9af3c2", "B7.0-PLAIN-9af3c2", "B7.1-PLAIN-9af3c", "B7.1-PLAIN-9af3c2d", "B7.1-PLAIN-9af3g2", "B7.1-PLAIN-STEER-9af3c2", " B7.1-PLAIN-9af3c2", "B7.1-PLAIN-9af3c2\t", "").forEach { raw ->
+            assertNull(DebugFixtures.parseBurstInput(raw)); assertNotNull(DebugFixtures.rejectionLine(raw))
+        }
+        assertEquals("burst.driver reject reason=malformed-nonce value=\"B7.1-F2-9af3c2\"", DebugFixtures.rejectionLine("B7.1-F2-9af3c2"))
+        assertEquals("burst.driver reject reason=malformed-nonce value=\"B7.1-PLAIN-STEER-9af3c2\"", DebugFixtures.rejectionLine("B7.1-PLAIN-STEER-9af3c2"))
+        assertEquals("burst.driver reject reason=missing-nonce", DebugFixtures.rejectionLine(""))
+        assertNull(DebugFixtures.rejectionLine(null)); assertNull(DebugFixtures.rejectionLine("B7.1-PLAIN-9af3c2"))
+    }
+    @Test fun parseTimingsAndCheckpointWindows() {
+        assertEquals(listOf(200L, 400L, 700L), DebugFixtures.parseTimings(null)); assertEquals(listOf(10L, 2000L, 700L), DebugFixtures.parseTimings("1, 9999"))
+        assertEquals(listOf(50L, 60L, 70L), DebugFixtures.parseTimings("50,60,70,80")); assertEquals(listOf(200L, 400L, 700L), DebugFixtures.parseTimings("abc"))
+        assertEquals(listOf(200L, 60L, 70L), DebugFixtures.parseTimings("abc, 60, 70")); assertEquals(listOf(1 to 1_100L, 2 to 1_100L, 0 to 1_300L), DebugFixtures.burstPlan(listOf(300L, 100L, 100L), 1_000L)) // equal offsets ⇒ index order
+        assertEquals(16_000L, DebugFixtures.checkpointDelayMs(listOf(200L, 400L, 700L), false))
+        assertEquals(28_000L, DebugFixtures.checkpointDelayMs(listOf(200L, 400L), true))
+    }
+    @Test fun driverIsArmGatedOneShotOnBothAnchorsAndRecursionGuarded() {
+        val d = DebugFixtures.BurstDriver(listOf(200L, 400L, 700L), v("B7.1-PLAIN-9af3c2"), true)
+        assertNull(d.onStartTurnEntered(DebugFixtures.T0_PROMPT, 1_000L)); assertEquals(DebugFixtures.BurstDriver.Phase.IDLE, d.phase) // unarmed stays IDLE
+        d.arm()
+        assertEquals(listOf(0 to 1_200L, 1 to 1_400L, 2 to 1_700L), d.onStartTurnEntered(DebugFixtures.T0_PROMPT, 1_000L))
+        assertNull(d.onStartTurnEntered(DebugFixtures.T0_LONG_PROMPT, 2_000L)); assertNull(d.onStartTurnEntered(DebugFixtures.followUpTexts(d.input)[0], 3_000L)) // one-shot; driver-fired follow-up cannot re-anchor
+        val e = DebugFixtures.BurstDriver(listOf(200L), v("B12.2-STEER-00ffee"), false)
+        e.arm(); assertEquals(listOf(0 to 5_200L), e.onStartTurnEntered(DebugFixtures.T0_LONG_PROMPT, 5_000L)); assertTrue(e.anchorIsLong); assertFalse(e.fixtureMode)
+        val texts = DebugFixtures.followUpTexts(v("B12.2-STEER-00ffee")); assertTrue(e.isFollowUpText(texts[2])); assertFalse(e.isFollowUpText(texts[2] + " nope"))
+    }
+    @Test fun fixtureSnapshotIsDeterministicSixCaseCycleWithPerThreadSummaries() {
+        val snap = DebugFixtures.makeSnapshot(300, 1500); assertEquals(snap, DebugFixtures.makeSnapshot(300, 1500))
+        assertEquals(300, snap.threads.size); assertEquals(1500, snap.threads[0].hydratedConversationItems.size)
+        val items = snap.threads[0].hydratedConversationItems
+        assertTrue(items[0].content is HydratedConversationItemContent.User); assertTrue(items[1].content is HydratedConversationItemContent.Assistant)
+        assertTrue(items[2].content is HydratedConversationItemContent.Reasoning); assertTrue(items[3].content is HydratedConversationItemContent.CommandExecution)
+        assertTrue(items[4].content is HydratedConversationItemContent.McpToolCall); assertTrue(items[5].content is HydratedConversationItemContent.CommandExecution)
+        val cmd = (items[3].content as HydratedConversationItemContent.CommandExecution).v1; assertEquals("/Projects/Workspace-3", cmd.cwd); assertEquals("fixture output 3", cmd.output); assertEquals(120L, cmd.durationMs)
+        val tool = (items[4].content as HydratedConversationItemContent.McpToolCall).v1; assertEquals("fixtureTool", tool.tool); assertEquals("{}", tool.argumentsJson); assertEquals("Fixture tool summary 4.", tool.contentSummary)
+        assertEquals("sleep 3", (items[5].content as HydratedConversationItemContent.CommandExecution).v1.command)
+        assertEquals("fixture-thread-0", snap.threads[9].info.parentThreadId); assertEquals(1_700_000_000L - 9, snap.threads[9].info.updatedAt)
+        assertEquals("Fixture thread 30", snap.sessionSummaries[30].title); assertEquals("/Projects/Workspace-1", snap.sessionSummaries[30].cwd)
+        assertEquals("Fixture preview 0", snap.sessionSummaries[0].preview); assertEquals(snap.threads[0].key, DebugFixtures.fixtureThreadKey)
+        assertFalse(snap.threads[0].hydratedConversationItems.any { it.id == "fixture-live-assistant-1" }); assertTrue(snap.threads[1].hydratedConversationItems.any { it.id == "fixture-live-assistant-1" })
+    }
+    @Test fun burstRoutesToThread0ItemWhileForeignStreamStaysOnThread1() {
+        val texts = DebugFixtures.followUpTexts(v("B7.1-PLAIN-9af3c2")); val f1 = DebugFixtures.burstUpdates(0, DebugFixtures.fixtureThreadKey, texts)[0] as AppStoreUpdateRecord.ThreadMetadataChanged
+        val f2 = DebugFixtures.burstUpdates(1, DebugFixtures.fixtureThreadKey, texts); assertEquals(1, f1.state.queuedFollowUps.size); assertEquals(2, (f2[0] as AppStoreUpdateRecord.ThreadMetadataChanged).state.queuedFollowUps.size)
+        val delta = f2[1] as AppStoreUpdateRecord.ThreadStreamingDelta; assertEquals(DebugFixtures.fixtureThreadKey, delta.key)
+        val t0 = DebugFixtures.makeSnapshot(2, 2).threads[0].hydratedConversationItems.map { it.id }; val t1 = DebugFixtures.makeSnapshot(2, 2).threads[1].hydratedConversationItems.map { it.id }
+        assertTrue(t0.contains(delta.itemId)); assertFalse(t0.contains("fixture-live-assistant-1")); assertTrue(t1.contains("fixture-live-assistant-1"))
+        assertTrue((DebugFixtures.burstDrainUpdate(DebugFixtures.fixtureThreadKey) as AppStoreUpdateRecord.ThreadMetadataChanged).state.queuedFollowUps.isEmpty())
+    }
+    @Test fun ledgerRingCapsAt512AndFlushClearsOnlyTheEmittedBatch() {
+        DebugFixtures.flushLedger("drain") { }; repeat(600) { DebugFixtures.appendLedger("line$it") }
+        val out = mutableListOf<String>(); DebugFixtures.flushLedger("test") { out += it }
+        assertEquals(513, out.size); assertEquals("burst.ledger flush reason=test entries=512 dropped=88", out[0]); assertEquals("line88", out[1]); assertEquals("line599", out.last()) // A-1 chronology: oldest surviving → newest
+        val again = mutableListOf<String>(); DebugFixtures.flushLedger("test2") { again += it }; assertTrue(again.isEmpty())
+        DebugFixtures.appendLedger("kept"); DebugFixtures.flushLedger("boom") { throw java.lang.IllegalStateException() }
+        val kept = mutableListOf<String>(); DebugFixtures.flushLedger("on-stop") { kept += it }; assertEquals(listOf("burst.ledger flush reason=on-stop entries=1 dropped=0", "kept"), kept)
+    }
+}

--- a/apps/android/app/src/test/java/com/litter/android/state/ThreadRevisionLedgerTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/state/ThreadRevisionLedgerTest.kt
@@ -47,7 +47,7 @@ class ThreadRevisionLedgerTest {
         val a = key("a")
         val n = 50
         val m = 100
-        coroutineScope { (1..n).map { async(Dispatchers.Default) { repeat(m) { ledger.bumpThread(a) } }.awaitAll() } }
+        coroutineScope { (1..n).map { async(Dispatchers.Default) { repeat(m) { ledger.bumpThread(a) } } }.awaitAll() }
         assertEquals((n * m).toLong(), ledger.threadRevision(a).value)
     }
 }

--- a/apps/android/app/src/test/java/com/litter/android/state/ThreadRevisionLedgerTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/state/ThreadRevisionLedgerTest.kt
@@ -1,0 +1,53 @@
+package com.litter.android.state
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import uniffi.codex_mobile_client.ThreadKey
+
+class ThreadRevisionLedgerTest {
+    private fun key(id: String) = ThreadKey(serverId = "srv", threadId = id)
+
+    @Test
+    fun `L1 bumpThread bumps only the target thread flow`() {
+        val ledger = ThreadRevisionLedger()
+        ledger.bumpThread(key("a"))
+        assertEquals(1L, ledger.threadRevision(key("a")).value)
+        assertEquals(0L, ledger.threadRevision(key("b")).value)
+        assertEquals(0L, ledger.conversationGlobalRevision.value)
+    }
+
+    @Test
+    fun `L2 bumpGlobal bumps only the global flow`() {
+        val ledger = ThreadRevisionLedger()
+        ledger.bumpThread(key("a"))
+        ledger.bumpGlobal()
+        assertEquals(1L, ledger.conversationGlobalRevision.value)
+        assertEquals(1L, ledger.threadRevision(key("a")).value)
+        assertEquals(0L, ledger.threadRevision(key("b")).value)
+    }
+
+    @Test
+    fun `L3 threadRevision returns the same flow instance across calls and bumps`() {
+        val ledger = ThreadRevisionLedger()
+        val flow1 = ledger.threadRevision(key("a"))
+        ledger.bumpThread(key("a"))
+        assertSame(flow1, ledger.threadRevision(key("a")))
+        assertEquals(1L, flow1.value)
+    }
+
+    @Test
+    fun `L4 concurrency N coroutines times M bumps yields exactly N times M`() = runBlocking {
+        val ledger = ThreadRevisionLedger()
+        val a = key("a")
+        val n = 50
+        val m = 100
+        coroutineScope { (1..n).map { async(Dispatchers.Default) { repeat(m) { ledger.bumpThread(a) } }.awaitAll() } }
+        assertEquals((n * m).toLong(), ledger.threadRevision(a).value)
+    }
+}

--- a/apps/ios/Sources/Litter/Extensions.swift
+++ b/apps/ios/Sources/Litter/Extensions.swift
@@ -122,7 +122,7 @@ enum FontFamilyOption: String, CaseIterable, Identifiable {
     var displayName: String {
         switch self {
         case .mono: return "Berkeley Mono"
-        case .system: return "ChatGPT (System)"
+        case .system: return "System UI"
         case .systemMono: return "System Mono"
         case .serif: return "Reader Serif"
         }

--- a/apps/ios/Sources/Litter/Extensions.swift
+++ b/apps/ios/Sources/Litter/Extensions.swift
@@ -311,6 +311,13 @@ enum LitterFont {
         max(UIFont.preferredFont(forTextStyle: .body).pointSize - 1, 15)
     }
 
+    static var conversationCodePointSize: CGFloat {
+        // Code is supporting material in a conversation. A one-step smaller
+        // monospaced face keeps prose as the primary reading surface without
+        // making commands or snippets hard to inspect.
+        max(UIFont.preferredFont(forTextStyle: .callout).pointSize - 1, 14)
+    }
+
     static var conversationDiffPointSize: CGFloat {
         UIFont.preferredFont(forTextStyle: .caption1).pointSize
     }

--- a/apps/ios/Sources/Litter/LitterApp.swift
+++ b/apps/ios/Sources/Litter/LitterApp.swift
@@ -303,6 +303,10 @@ struct LitterApp: App {
                 .environment(themeManager)
                 .environment(wallpaperManager)
                 .task {
+                    #if DEBUG
+                    if appModel.applyDebugProductionFixtureIfRequested() { return }
+                    appModel.debugArmBurstDriverIfRequested()
+                    #endif
                     appModel.start()
                     voiceRuntime.bind(appModel: appModel)
                     appRuntime.bind(appModel: appModel, voiceRuntime: voiceRuntime)
@@ -328,6 +332,9 @@ struct LitterApp: App {
             switch newPhase {
             case .background:
                 appRuntime.appDidEnterBackground()
+                #if DEBUG
+                appModel.debugFlushIngressLedger(reason: "background")
+                #endif
             case .inactive:
                 appRuntime.appDidBecomeInactive()
             case .active:
@@ -418,6 +425,9 @@ struct ContentView: View {
                 standardOverlays
                 #endif
 
+                #if DEBUG
+                DebugPerfOverlays(appModel: appModel)
+                #endif
             }
             .ignoresSafeArea(.container)
             .task {
@@ -2256,3 +2266,32 @@ struct LaunchView: View {
         }
     }
 }
+
+#if DEBUG
+/// W1 measurement-only seams: A-10 burst beacon (top-leading, ~66 ms blink per driver fire)
+/// and fixture-gated counter readout/publish/reset (harness a11y pattern).
+private struct DebugPerfOverlays: View {
+    let appModel: AppModel
+    @State private var publishedCountersJSON = ""
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            TimelineView(.periodic(from: .now, by: 0.02)) { _ in
+                if appModel.debugBeaconVisible {
+                    RoundedRectangle(cornerRadius: 3).fill(.white).overlay(RoundedRectangle(cornerRadius: 3).strokeBorder(.black, lineWidth: 2)).frame(width: 14, height: 14).padding(4)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .allowsHitTesting(false)
+            if appModel.debugFixtureActive {
+                HStack(spacing: 4) {
+                    Text("counters").font(.system(size: 1)).accessibilityIdentifier("fixture.counterReadout").accessibilityValue(Text(publishedCountersJSON))
+                    Button("reset") { RenderIsolationCounters.reset(); publishedCountersJSON = "{}" }.accessibilityIdentifier("fixture.resetCounters").font(.system(size: 8)).frame(width: 20, height: 20)
+                    Button("publish") { publishedCountersJSON = RenderIsolationCounters.json }.accessibilityIdentifier("fixture.publishCounters").font(.system(size: 8)).frame(width: 20, height: 20)
+                }
+                .padding(4).background(LitterTheme.surface.opacity(0.4))
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+            }
+        }
+    }
+}
+#endif

--- a/apps/ios/Sources/Litter/LitterApp.swift
+++ b/apps/ios/Sources/Litter/LitterApp.swift
@@ -1955,7 +1955,10 @@ private struct ConversationDestinationScreen: View {
                 .onChange(of: conversationThread) { _, updatedThread in
                     bindScreenModel(for: updatedThread)
                 }
-                .onChange(of: appModel.snapshotRevision) { _, _ in
+                .onChange(of: appModel.threadRebindSignal(for: resolvedThreadKey).revision) { _, _ in
+                    bindScreenModel(for: conversationThread)
+                }
+                .onChange(of: appModel.conversationGlobalRevision) { _, _ in
                     bindScreenModel(for: conversationThread)
                 }
                 .onChange(of: pendingUserInputsForThread) { _, _ in

--- a/apps/ios/Sources/Litter/Models/AppModel.swift
+++ b/apps/ios/Sources/Litter/Models/AppModel.swift
@@ -21,6 +21,13 @@ enum LocalAccountLoginFlowError: LocalizedError {
 
 @MainActor
 @Observable
+final class ThreadRebindSignal {
+    private(set) var revision: UInt64 = 0
+    func bump() { revision &+= 1 }
+}
+
+@MainActor
+@Observable
 final class AppModel {
     private struct PendingThreadStateEvent: Sendable {
         let state: AppThreadStateRecord
@@ -99,6 +106,14 @@ final class AppModel {
         }
     }
     private(set) var snapshotRevision: UInt64 = 0
+    private(set) var conversationGlobalRevision: UInt64 = 0
+    @ObservationIgnored private var threadRebindSignals: [ThreadKey: ThreadRebindSignal] = [:]
+    func threadRebindSignal(for key: ThreadKey) -> ThreadRebindSignal {
+        if let existing = threadRebindSignals[key] { return existing }
+        let signal = ThreadRebindSignal()
+        threadRebindSignals[key] = signal
+        return signal
+    }
     private(set) var lastError: String?
     private(set) var composerPrefillRequest: ComposerPrefillRequest?
 
@@ -800,7 +815,9 @@ final class AppModel {
     func applySnapshot(_ snapshot: AppSnapshotRecord?) {
         let normalizedSnapshot = snapshot.map(normalizingLocalServerDisplayNames)
         let mergedSnapshot = normalizedSnapshot.map(mergingCachedThreadSnapshots)
+        let revisionBefore = snapshotRevision
         self.snapshot = mergedSnapshot
+        if snapshotRevision != revisionBefore { conversationGlobalRevision &+= 1 }
         if let mergedSnapshot {
             persistWakeMACs(from: mergedSnapshot.servers)
             mergedSnapshot.threads.forEach(cacheThreadSnapshot)
@@ -881,6 +898,7 @@ final class AppModel {
             removeThreadSnapshot(for: key, agentDirectoryVersion: agentDirectoryVersion)
         case .activeThreadChanged(let key):
             updateActiveThread(key)
+            conversationGlobalRevision &+= 1
             if let key, threadSnapshot(for: key) == nil {
                 await refreshThreadSnapshot(key: key)
             }
@@ -921,6 +939,10 @@ final class AppModel {
             await refreshSnapshot()
         }
     }
+
+    #if DEBUG
+    func _testHandleStoreUpdate(_ update: AppStoreUpdateRecord) async { await handleStoreUpdate(update) }
+    #endif
 
     /// Mutate an in-flight widget bubble's `HydratedWidgetData` so the
     /// timeline `WidgetWebView` picks up the growing HTML via its existing
@@ -1657,6 +1679,7 @@ final class AppModel {
             snapshot.agentDirectoryVersion = agentDirectoryVersion
         }
         self.snapshot = snapshot
+        threadRebindSignal(for: key).bump()
         if clearCache {
             cachedThreadSnapshots.removeValue(forKey: key)
         }
@@ -2073,7 +2096,9 @@ final class AppModel {
     }
 
     private func cacheThreadSnapshot(_ thread: AppThreadSnapshot) {
+        let changed = cachedThreadSnapshots[thread.key] != thread
         cachedThreadSnapshots[thread.key] = thread
+        if changed { threadRebindSignal(for: thread.key).bump() }
     }
 
     private func mergedThreadSnapshotPreservingHydratedItems(_ thread: AppThreadSnapshot) -> AppThreadSnapshot {

--- a/apps/ios/Sources/Litter/Models/AppModel.swift
+++ b/apps/ios/Sources/Litter/Models/AppModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Observation
 import UIKit
+import os
 
 enum LocalAccountLoginFlowError: LocalizedError {
     case localServerUnavailable
@@ -233,6 +234,9 @@ final class AppModel {
     }
 
     private func performSnapshotRefresh() async {
+        #if DEBUG
+        guard !debugFixtureActive else { return }
+        #endif
         do {
             applySnapshot(try await store.snapshot())
         } catch {
@@ -849,6 +853,9 @@ final class AppModel {
     }
 
     private func handleStoreUpdate(_ update: AppStoreUpdateRecord) async {
+        #if DEBUG
+        let debugArrival = debugIngressArrival(update)
+        #endif
         switch update {
         case .threadUpserted(let thread, let sessionSummary, let agentDirectoryVersion):
             applyThreadUpsert(
@@ -938,6 +945,9 @@ final class AppModel {
         case .terminalSessionsChanged:
             await refreshSnapshot()
         }
+        #if DEBUG
+        debugRecordIngressPostApply(arrival: debugArrival)
+        #endif
     }
 
     #if DEBUG
@@ -1873,6 +1883,9 @@ final class AppModel {
     }
 
     func startTurn(key: ThreadKey, payload: AppComposerPayload) async throws {
+        #if DEBUG
+        if debugBurstDriver?.noteStartTurnEntered(key: key, text: payload.text) == true { return }
+        #endif
         await restoreStoredLocalAuthIfNeeded(serverId: key.serverId, reason: "startTurn")
 
         do {
@@ -2145,6 +2158,109 @@ final class AppModel {
 
         return snapshot
     }
+
+    #if DEBUG
+    @ObservationIgnored private(set) var debugFixtureActive = false
+    @ObservationIgnored private(set) var debugBeaconRevision: UInt64 = 0
+    @ObservationIgnored private(set) var debugBeaconVisibleUntilMs: UInt64 = 0
+    var debugBeaconVisible: Bool { debugBeaconVisibleUntilMs >= DebugPerfClock.monoMs() }
+    @ObservationIgnored private var debugBurstDriver: DebugBurstDriver?
+    @ObservationIgnored var debugIngressLedger: [String] = []
+    @ObservationIgnored var debugIngressDropped = 0
+    @ObservationIgnored private var debugWatchdogTask: Task<Void, Never>?
+    @ObservationIgnored private var debugForeignStreamTask: Task<Void, Never>?
+
+    func debugBeaconBlink() { debugBeaconRevision &+= 1; debugBeaconVisibleUntilMs = DebugPerfClock.monoMs() + 66 }
+    func debugAppendLedger(_ line: String) {
+        debugIngressLedger.append(line)
+        if debugIngressLedger.count > 512 { let overflow = debugIngressLedger.count - 512; debugIngressDropped += overflow; debugIngressLedger.removeFirst(overflow) }
+    }
+    struct DebugIngressArrival { let monoMs: UInt64; let wallMs: UInt64; let variant: String; let key: ThreadKey?; let queued: Int?; let steerKinds: String; let activeTurn: String? }
+    func debugIngressArrival(_ update: AppStoreUpdateRecord) -> DebugIngressArrival {
+        var key: ThreadKey?, queued: Int?, activeTurn: String?, m = 0, p = 0, r = 0
+        func tally(_ previews: [AppQueuedFollowUpPreview]) -> Int {
+            for q in previews { switch q.kind { case .message: m += 1; case .pendingSteer: p += 1; default: r += 1 } }
+            return previews.count
+        }
+        switch update {
+        case .threadUpserted(let t, _, _): key = t.key; queued = tally(t.queuedFollowUps); activeTurn = t.activeTurnId
+        case .threadMetadataChanged(let s, _, _): key = s.key; queued = tally(s.queuedFollowUps); activeTurn = s.activeTurnId
+        case .threadItemChanged(let k, _, _): key = k
+        case .threadStreamingDelta(let k, _, _, _): key = k
+        case .threadRemoved(let k, _): key = k
+        case .activeThreadChanged(let k): key = k
+        case .dynamicWidgetStreaming(let k, _, _, _): key = k
+        default: break
+        }
+        return DebugIngressArrival(monoMs: DebugPerfClock.monoMs(), wallMs: DebugPerfClock.wallMs(), variant: Mirror(reflecting: update).children.first?.label ?? String(describing: update), key: key, queued: queued, steerKinds: queued != nil ? "\(m)/\(p)/\(r)" : "-", activeTurn: activeTurn)
+    }
+    func debugRecordIngressPostApply(arrival: DebugIngressArrival) {
+        let line = "burst.ingress arriveMs=\(arrival.monoMs) applyMs=\(DebugPerfClock.monoMs()) wallMs=\(arrival.wallMs) variant=\(arrival.variant) threadKey=\(arrival.key.map { "\($0.serverId)/\($0.threadId)" } ?? "-") queued=\(arrival.queued.map(String.init) ?? "-") steerKinds=\(arrival.steerKinds) activeTurn=\(arrival.activeTurn ?? "-") rev=\(snapshotRevision)"
+        debugAppendLedger(line)
+        os_signpost(.event, log: PerfAttribution.log, name: "burst.ingress", "%@", line)
+    }
+    @discardableResult
+    func debugFlushIngressLedger(reason: String = "manual") -> String? {
+        guard !debugIngressLedger.isEmpty else { return nil }
+        let header = "burst.ledger flush reason=\(reason) entries=\(debugIngressLedger.count) dropped=\(debugIngressDropped)"
+        NSLog("%@", header)
+        debugIngressLedger.forEach { NSLog("%@", $0) }
+        debugIngressLedger.removeAll(); debugIngressDropped = 0
+        return header
+    }
+    private func debugStartWatchdog() {
+        guard debugWatchdogTask == nil else { return }
+        debugWatchdogTask = Task { [weak self] in
+            var lastMs = DebugPerfClock.monoMs()
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 250_000_000)
+                guard let self else { return }
+                let nowMs = DebugPerfClock.monoMs(); let gapMs = nowMs - lastMs; lastMs = nowMs
+                if gapMs > 500 { self.debugAppendLedger("burst.watchdog gapMs=\(gapMs) t=\(nowMs) wallMs=\(DebugPerfClock.wallMs())") }
+            }
+        }
+    }
+
+    private func debugStartForeignStream(key: ThreadKey, itemId: String, intervalMs: UInt64) {
+        guard debugForeignStreamTask == nil, intervalMs > 0 else { return }
+        debugForeignStreamTask = Task { [weak self] in
+            var n = 0
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: intervalMs * 1_000_000)
+                guard let self else { return }
+                n += 1
+                await self._testHandleStoreUpdate(.threadStreamingDelta(key: key, itemId: itemId, kind: .assistantText, text: " f\u{3b4}\(n)"))
+            }
+        }
+    }
+
+    @discardableResult
+    func applyDebugProductionFixtureIfRequested() -> Bool {
+        let env = ProcessInfo.processInfo.environment
+        guard env["CODEXIOS_UI_TEST_PRODUCTION_FIXTURE"] == "1" else { return false }
+        let sessions = Int(env["CODEXIOS_UI_TEST_SESSION_COUNT"] ?? "") ?? 300
+        let items = Int(env["CODEXIOS_UI_TEST_ITEM_COUNT"] ?? "") ?? 1500
+        applySnapshot(DebugProductionFixture.makeSnapshot(sessions: max(sessions, 2), items: items))
+        debugFixtureActive = true
+        debugArmBurstDriverIfRequested(environment: env)
+        if let raw = env["CODEXIOS_UI_TEST_STREAM_FOREIGN"], !raw.isEmpty {
+            let cadenceMs: UInt64 = raw == "1" ? 100 : UInt64(raw) ?? 100
+            debugStartForeignStream(key: DebugProductionFixture.liveThreadKey, itemId: DebugProductionFixture.liveAssistantItemId, intervalMs: cadenceMs)
+        }
+        debugStartWatchdog()
+        return true
+    }
+
+    @discardableResult
+    func debugArmBurstDriverIfRequested(environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
+        if debugBurstDriver == nil { debugBurstDriver = DebugBurstDriver() }
+        guard let driver = debugBurstDriver else { return false }
+        driver.armIfRequested(environment: environment, appModel: self)
+        guard driver.phase != .idle else { return false }
+        debugStartWatchdog()
+        return true
+    }
+    #endif
 }
 
 extension AppSnapshotRecord {
@@ -2186,3 +2302,168 @@ extension AppSnapshotRecord {
         return nil
     }
 }
+
+#if DEBUG
+enum PerfAttribution {
+    static let log = OSLog(subsystem: "com.sigkitten.litter", category: "PerfAttribution")
+    static func begin(_ name: StaticString) -> OSSignpostID {
+        let id = OSSignpostID(log: log); os_signpost(.begin, log: log, name: name, signpostID: id); return id
+    }
+    static func end(_ name: StaticString, _ id: OSSignpostID) { os_signpost(.end, log: log, name: name, signpostID: id) }
+}
+enum DebugPerfClock {
+    static func monoMs() -> UInt64 { DispatchTime.now().uptimeNanoseconds / 1_000_000 }
+    static func wallMs() -> UInt64 { UInt64(Date().timeIntervalSince1970 * 1000) }
+}
+extension Notification.Name { static let litterDebugBurstFire = Notification.Name("litter.debug.burstFire") }
+
+enum DebugProductionFixture {
+    static let epoch: Int64 = 1_700_000_000
+    static let serverId = "fixture-server"
+    static let liveAssistantItemId = "fixture-live-assistant-1"
+    static let liveThreadKey = ThreadKey(serverId: serverId, threadId: "fixture-thread-1")
+
+    static func item(at i: Int) -> HydratedConversationItem {
+        let id = "fixture-item-\(i)", turn = UInt32(i / 6), slot = UInt32(i % 6), ts = Double(epoch) + Double(i), turnId = "fixture-turn-\(turn)"
+        switch i % 6 {
+        case 0: return HydratedConversationItem(id: id, content: .user(HydratedUserMessageData(text: "Fixture user message \(i).", imageDataUris: [])), sourceTurnId: turnId, sourceTurnIndex: slot, timestamp: ts, isFromUserTurnBoundary: true)
+        case 1: return HydratedConversationItem(id: id, content: .assistant(HydratedAssistantMessageData(text: "Fixture assistant reply \(i).", agentNickname: nil, agentRole: nil, phase: .finalAnswer)), sourceTurnId: turnId, sourceTurnIndex: slot, timestamp: ts, isFromUserTurnBoundary: false)
+        case 2: return HydratedConversationItem(id: id, content: .reasoning(HydratedReasoningData(summary: ["Fixture reasoning \(i)."], content: [])), sourceTurnId: turnId, sourceTurnIndex: slot, timestamp: ts, isFromUserTurnBoundary: false)
+        case 3: return HydratedConversationItem(id: id, content: .commandExecution(HydratedCommandExecutionData(command: "echo fixture-\(i)", cwd: "/Projects/Workspace-\(i % 12)", status: .completed, output: "fixture output \(i)", exitCode: 0, durationMs: 120, processId: nil, actions: [])), sourceTurnId: turnId, sourceTurnIndex: slot, timestamp: ts, isFromUserTurnBoundary: false)
+        case 4: return HydratedConversationItem(id: id, content: .mcpToolCall(HydratedMcpToolCallData(server: "fixture-mcp", tool: "fixtureTool", status: .completed, durationMs: 80, argumentsJson: "{}", contentSummary: "Fixture tool summary \(i).", structuredContentJson: nil, rawOutputJson: nil, errorMessage: nil, progressMessages: [], computerUse: nil)), sourceTurnId: turnId, sourceTurnIndex: slot, timestamp: ts, isFromUserTurnBoundary: false)
+        default: return HydratedConversationItem(id: id, content: .commandExecution(HydratedCommandExecutionData(command: "sleep \(i % 3 + 1)", cwd: "/Projects/Workspace-\(i % 12)", status: .inProgress, output: nil, exitCode: nil, durationMs: nil, processId: nil, actions: [])), sourceTurnId: turnId, sourceTurnIndex: slot, timestamp: ts, isFromUserTurnBoundary: false)
+        }
+    }
+
+    static func makeThread(index i: Int, items: [HydratedConversationItem]) -> AppThreadSnapshot {
+        AppThreadSnapshot(
+            key: ThreadKey(serverId: serverId, threadId: "fixture-thread-\(i)"),
+            info: ThreadInfo(id: "fixture-thread-\(i)", title: "Fixture thread \(i)", model: "gpt-fixture", status: .idle, preview: "Fixture preview \(i)", cwd: "/Projects/Workspace-\(i / 25)", path: nil, modelProvider: "openai", agentNickname: nil, agentRole: nil, parentThreadId: i > 0 && i % 10 == 9 ? "fixture-thread-\(i - 9)" : nil, forkedFromId: nil, agentStatus: nil, createdAt: epoch - Int64(i) - 3_600, updatedAt: epoch - Int64(i)),
+            agentRuntimeKind: "codex", collaborationMode: .default, model: "gpt-fixture", reasoningEffort: nil, effectiveApprovalPolicy: nil, effectiveSandboxPolicy: nil, hydratedConversationItems: items, queuedFollowUps: [], activeTurnId: nil, activePlanProgress: nil, pendingPlanImplementationPrompt: nil, contextTokensUsed: nil, modelContextWindow: nil, rateLimits: nil, realtimeSessionId: nil, goal: nil, stats: nil, tokenUsage: nil, olderTurnsCursor: nil, initialTurnsLoaded: true
+        )
+    }
+
+    static func summary(for thread: AppThreadSnapshot) -> AppSessionSummary {
+        AppSessionSummary(key: thread.key, agentRuntimeKind: thread.agentRuntimeKind, serverDisplayName: "Fixture Studio", serverHost: "fixture.local", title: thread.info.title ?? "", preview: thread.info.preview ?? "", cwd: thread.info.cwd ?? "", model: thread.model ?? "", modelProvider: thread.info.modelProvider ?? "", parentThreadId: thread.info.parentThreadId, forkedFromId: nil, agentNickname: nil, agentRole: nil, agentDisplayLabel: thread.key.threadId, agentStatus: .unknown, updatedAt: thread.info.updatedAt, hasActiveTurn: thread.activeTurnId != nil, isResumed: false, isSubagent: false, isFork: false, lastResponsePreview: nil, lastResponseTurnId: nil, lastUserMessage: nil, lastToolLabel: nil, recentToolLog: [], lastTurnStartMs: nil, lastTurnEndMs: nil, stats: nil, tokenUsage: nil, goal: nil)
+    }
+
+    static func makeSnapshot(sessions: Int, items: Int) -> AppSnapshotRecord {
+        var threads: [AppThreadSnapshot] = []
+        for i in 0..<max(sessions, 2) {
+            let threadItems: [HydratedConversationItem]
+            if i == 0 { threadItems = (0..<max(items, 0)).map(item(at:)) } else if i == 1 {
+                threadItems = [
+                    HydratedConversationItem(id: "fixture-live-user-1", content: .user(HydratedUserMessageData(text: "Fixture live turn.", imageDataUris: [])), sourceTurnId: "fixture-live-turn", sourceTurnIndex: 0, timestamp: Double(epoch) + 10, isFromUserTurnBoundary: true),
+                    HydratedConversationItem(id: liveAssistantItemId, content: .assistant(HydratedAssistantMessageData(text: "Fixture live stream.", agentNickname: nil, agentRole: nil, phase: .commentary)), sourceTurnId: "fixture-live-turn", sourceTurnIndex: 1, timestamp: Double(epoch) + 11, isFromUserTurnBoundary: false),
+                    HydratedConversationItem(id: "fixture-live-assistant-2", content: .assistant(HydratedAssistantMessageData(text: "Done.", agentNickname: nil, agentRole: nil, phase: .finalAnswer)), sourceTurnId: "fixture-live-turn", sourceTurnIndex: 2, timestamp: Double(epoch) + 12, isFromUserTurnBoundary: false)
+                ]
+            } else { threadItems = [] }
+            threads.append(makeThread(index: i, items: threadItems))
+        }
+        let server = AppServerSnapshot(serverId: serverId, displayName: "Fixture Studio", host: "fixture.local", port: 8390, wakeMac: nil, isLocal: false, health: .connected, transportState: .connected, capabilities: AppServerCapabilities(canUseTransportActions: true, canBrowseDirectories: true, canStartThreads: true, canResumeThreads: true, supportsTurnPagination: false), account: nil, requiresOpenaiAuth: false, rateLimits: nil, rateLimitsByRuntime: [], availableModels: nil, agentRuntimes: [AgentRuntimeInfo(kind: .codex, name: "codex", displayName: "Codex", available: true)], connectionProgress: nil, usageStats: nil)
+        return AppSnapshotRecord(servers: [server], threads: threads, sessionSummaries: threads.map { summary(for: $0) }, agentDirectoryVersion: 0, activeThread: nil, pendingApprovals: [], pendingUserInputs: [], voiceSession: AppVoiceSessionSnapshot(activeThread: nil, sessionId: nil, phase: nil, lastError: nil, transcriptEntries: [], handoffThreadKey: nil), terminalSessions: [], activeTerminalId: nil)
+    }
+
+    static func burstState(_ key: ThreadKey, status: ThreadSummaryStatus, activeTurnId: String?, queued: [AppQueuedFollowUpPreview]) -> AppThreadStateRecord {
+        AppThreadStateRecord(key: key, info: ThreadInfo(id: key.threadId, title: "Fixture thread", model: "gpt-fixture", status: status, preview: "Fixture preview", cwd: "/Projects/Workspace-0", path: nil, modelProvider: "openai", agentNickname: nil, agentRole: nil, parentThreadId: nil, forkedFromId: nil, agentStatus: nil, createdAt: epoch, updatedAt: epoch), agentRuntimeKind: "codex", collaborationMode: .default, model: "gpt-fixture", reasoningEffort: nil, effectiveApprovalPolicy: nil, effectiveSandboxPolicy: nil, queuedFollowUps: queued, activeTurnId: activeTurnId, activePlanProgress: nil, pendingPlanImplementationPrompt: nil, contextTokensUsed: nil, modelContextWindow: nil, rateLimits: nil, realtimeSessionId: nil, goal: nil, olderTurnsCursor: nil, initialTurnsLoaded: true)
+    }
+
+    static func burstSummary(_ key: ThreadKey, active: Bool, updatedAt: Int64) -> AppSessionSummary {
+        AppSessionSummary(key: key, agentRuntimeKind: "codex", serverDisplayName: "Fixture Studio", serverHost: "fixture.local", title: "Fixture thread", preview: "Fixture preview", cwd: "/Projects/Workspace-0", model: "gpt-fixture", modelProvider: "openai", parentThreadId: nil, forkedFromId: nil, agentNickname: nil, agentRole: nil, agentDisplayLabel: key.threadId, agentStatus: .unknown, updatedAt: updatedAt, hasActiveTurn: active, isResumed: false, isSubagent: false, isFork: false, lastResponsePreview: nil, lastResponseTurnId: nil, lastUserMessage: nil, lastToolLabel: nil, recentToolLog: [], lastTurnStartMs: nil, lastTurnEndMs: nil, stats: nil, tokenUsage: nil, goal: nil)
+    }
+
+    static func burstUpdates(index: Int, key: ThreadKey, texts: [String]) -> [AppStoreUpdateRecord] {
+        let queued = texts.prefix(index + 1).enumerated().map { AppQueuedFollowUpPreview(id: "fixture-burst-followup-\($0.offset)", kind: .message, text: $0.element) }
+        return [.threadMetadataChanged(state: burstState(key, status: .active, activeTurnId: "fixture-burst-turn", queued: Array(queued)), sessionSummary: burstSummary(key, active: true, updatedAt: epoch), agentDirectoryVersion: 0), .threadStreamingDelta(key: key, itemId: "fixture-item-1", kind: .assistantText, text: " F\(index + 1) burst \u{3b4}")]
+    }
+
+    static func burstDrainUpdate(key: ThreadKey) -> AppStoreUpdateRecord {
+        .threadMetadataChanged(state: burstState(key, status: .idle, activeTurnId: nil, queued: []), sessionSummary: burstSummary(key, active: false, updatedAt: epoch + 1), agentDirectoryVersion: 0)
+    }
+}
+
+@MainActor
+final class DebugBurstDriver {
+    enum Phase { case idle, armed, fired }
+    enum SteerMode: String { case plain = "PLAIN", steer = "STEER" }
+    struct Configuration { let offsetsMs: [Int]; let trial: String; let attempt: String; let mode: SteerMode; let hex: String; let raw: String; let fixtureMode: Bool }
+
+    static let anchorPrompt = "Run the command sh -c 'for i in 1 2 3 4 5 6 7 8; do echo tick $i; sleep 1; done' and then summarize its output in one sentence."
+    static let anchorPromptLong = "Run the command sh -c 'for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do echo tick $i; sleep 1; done' and then summarize its output in one sentence."
+    static let defaultOffsetsMs = [200, 400, 700]
+    static let inputPattern = try! NSRegularExpression(pattern: #"^B([1-9][0-9]{0,2})\.([1-9][0-9]?)-(PLAIN|STEER)-([0-9a-f]{6})$"#)
+
+    static func wireNonce(_ configuration: Configuration, fire: Int) -> String { "B\(configuration.trial).\(configuration.attempt)-F\(fire)-\(configuration.hex)" }
+    static func followUpTexts(configuration: Configuration) -> [String] { ["Follow-up one \(wireNonce(configuration, fire: 1)): reply with exactly ALPHA.", "Follow-up two \(wireNonce(configuration, fire: 2)): reply with exactly \(configuration.mode == .steer ? "BRAVO-STEERED" : "BRAVO").", "Follow-up three \(wireNonce(configuration, fire: 3)): reply with exactly CHARLIE."] }
+    static func anchorWindowMs(for text: String) -> Int? { text == anchorPrompt ? 8_000 : text == anchorPromptLong ? 20_000 : nil }
+    static func checkpointDelayMs(lastFireOffsetMs: Int, commandWindowMs: Int) -> Int { max(lastFireOffsetMs + 1_000, commandWindowMs + 8_000) }
+
+    static func parseTimings(_ raw: String?) -> [Int] {
+        let fields = raw?.split(separator: ",", omittingEmptySubsequences: false).map { $0.trimmingCharacters(in: .whitespaces) } ?? []
+        return (0..<3).map { i in guard i < fields.count, let v = Int(fields[i]) else { return defaultOffsetsMs[i] }; return min(max(v, 10), 2000) }
+    }
+    static func rejectLine(_ reason: String, value: String? = nil) -> String { value.map { "burst.driver reject reason=\(reason) value=\"\($0)\"" } ?? "burst.driver reject reason=\(reason)" }
+
+    static func configuration(environment: [String: String]) -> Configuration? {
+        guard environment["CODEXIOS_UI_TEST_BURST_FOLLOWUPS"] == "1" else { return nil }
+        guard let input = environment["CODEXIOS_UI_TEST_BURST_NONCE"], !input.isEmpty else { NSLog("%@", rejectLine("missing-nonce")); return nil }
+        func malformed() { NSLog("%@", rejectLine("malformed-nonce", value: input)) }
+        guard let match = inputPattern.firstMatch(in: input, range: NSRange(input.startIndex..., in: input)) else { malformed(); return nil }
+        func group(_ index: Int) -> String? { Range(match.range(at: index), in: input).map { String(input[$0]) } }
+        guard let trial = group(1), let attempt = group(2), let mode = group(3).flatMap(SteerMode.init(rawValue:)), let hex = group(4) else { malformed(); return nil }
+        return Configuration(offsetsMs: parseTimings(environment["CODEXIOS_UI_TEST_BURST_TIMINGS_MS"]), trial: trial, attempt: attempt, mode: mode, hex: hex, raw: input, fixtureMode: environment["CODEXIOS_UI_TEST_PRODUCTION_FIXTURE"] == "1")
+    }
+
+    static func burstPlan(offsetsMs: [Int], anchorMs: UInt64) -> [(index: Int, intendedMs: UInt64)] {
+        offsetsMs.enumerated().map { (index: $0.offset, intendedMs: anchorMs + UInt64(max($0.element, 0))) }
+    }
+
+    private(set) var phase: Phase = .idle; private(set) var scheduledFireCount = 0
+    private var config: Configuration?; private weak var appModel: AppModel?; private var fixtureApplyChain: Task<Void, Never>?
+
+    func armIfRequested(environment: [String: String], appModel: AppModel) {
+        guard phase == .idle, let armed = Self.configuration(environment: environment) else { return }
+        config = armed; self.appModel = appModel; phase = .armed
+        NSLog("burst.driver idle->armed offsets=\(armed.offsetsMs.map(String.init).joined(separator: ",")) input=\(armed.raw) trial=\(armed.trial) attempt=\(armed.attempt) steer=\(armed.mode.rawValue) hex=\(armed.hex) mode=\(armed.fixtureMode ? "fixture" : "live")")
+    }
+
+    @discardableResult
+    func noteStartTurnEntered(key: ThreadKey, text: String) -> Bool {
+        guard let config else { return false }
+        if phase == .armed, let commandWindowMs = Self.anchorWindowMs(for: text) {
+            phase = .fired; scheduleFires(key, commandWindowMs: commandWindowMs); return config.fixtureMode
+        }
+        if phase == .fired, Self.followUpTexts(configuration: config).contains(text) { NSLog("burst.driver follow-up entry (recursion-guarded)") }
+        return false
+    }
+
+    private func scheduleFires(_ key: ThreadKey, commandWindowMs: Int) {
+        guard let config else { return }
+        let anchorMs = DebugPerfClock.monoMs(); NSLog("burst.driver armed->fired anchorMonoMs=\(anchorMs) wallMs=\(DebugPerfClock.wallMs())")
+        let plan = Self.burstPlan(offsetsMs: config.offsetsMs, anchorMs: anchorMs); let texts = Self.followUpTexts(configuration: config); let nonces = (1...3).map { Self.wireNonce(config, fire: $0) }
+        scheduledFireCount = plan.count
+        for entry in plan {
+            Task { [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(entry.intendedMs - anchorMs) * 1_000_000); self?.fire(index: entry.index, key: key, intendedMs: entry.intendedMs, texts: texts, nonces: nonces, config: config)
+            }
+        }
+        guard let lastMs = plan.map(\.intendedMs).max() else { return }
+        if config.fixtureMode {
+            Task { [weak self] in try? await Task.sleep(nanoseconds: UInt64(lastMs - anchorMs + 1_000) * 1_000_000); guard let self, let chain = self.fixtureApplyChain else { return }; await chain.value; await self.appModel?._testHandleStoreUpdate(DebugProductionFixture.burstDrainUpdate(key: key)) }
+        }
+        Task { [weak self] in try? await Task.sleep(nanoseconds: UInt64(Self.checkpointDelayMs(lastFireOffsetMs: Int(lastMs - anchorMs), commandWindowMs: commandWindowMs)) * 1_000_000); self?.appModel?.debugFlushIngressLedger(reason: "burst-checkpoint"); NSLog("burst.driver checkpoint") }
+    }
+
+    private func fire(index: Int, key: ThreadKey, intendedMs: UInt64, texts: [String], nonces: [String], config: Configuration) {
+        let actualMs = DebugPerfClock.monoMs(); NSLog("burst.driver fire F\(index + 1) intended=\(intendedMs) actual=\(actualMs) drift=\(actualMs &- intendedMs) nonce=\(nonces[index]) wallMs=\(DebugPerfClock.wallMs())")
+        appModel?.debugBeaconBlink()
+        guard index < texts.count else { return }
+        if config.fixtureMode {
+            let updates = DebugProductionFixture.burstUpdates(index: index, key: key, texts: texts)
+            fixtureApplyChain = Task { [previous = fixtureApplyChain, weak appModel] in await previous?.value; for update in updates { await appModel?._testHandleStoreUpdate(update) } }
+        } else {
+            NotificationCenter.default.post(name: .litterDebugBurstFire, object: nil, userInfo: ["key": key, "text": texts[index]])
+        }
+    }
+}
+#endif

--- a/apps/ios/Sources/Litter/Models/ThemeManager.swift
+++ b/apps/ios/Sources/Litter/Models/ThemeManager.swift
@@ -68,6 +68,8 @@ final class ThemeManager {
 
     private static let appGroupSuite = LitterPalette.appGroupSuite
     private static let appearanceModeKey = "appearanceMode"
+    private static let defaultLightThemeSlug = "studio-light"
+    private static let defaultDarkThemeSlug = "studio-dark"
 
     private(set) var lightTheme: ResolvedTheme = .defaultLight
     private(set) var darkTheme: ResolvedTheme = .defaultDark
@@ -77,12 +79,12 @@ final class ThemeManager {
     private var systemColorScheme: ColorScheme = .dark
 
     var selectedLightSlug: String {
-        get { UserDefaults.standard.string(forKey: "selectedLightTheme") ?? "codex-light" }
+        get { UserDefaults.standard.string(forKey: "selectedLightTheme") ?? Self.defaultLightThemeSlug }
         set { UserDefaults.standard.set(newValue, forKey: "selectedLightTheme") }
     }
 
     var selectedDarkSlug: String {
-        get { UserDefaults.standard.string(forKey: "selectedDarkTheme") ?? "chatgpt-dark" }
+        get { UserDefaults.standard.string(forKey: "selectedDarkTheme") ?? Self.defaultDarkThemeSlug }
         set { UserDefaults.standard.set(newValue, forKey: "selectedDarkTheme") }
     }
 

--- a/apps/ios/Sources/Litter/Views/CodeBlockView.swift
+++ b/apps/ios/Sources/Litter/Views/CodeBlockView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct CodeBlockView: View {
     let language: String
     let code: String
-    var fontSize: CGFloat = LitterFont.conversationBodyPointSize
+    var fontSize: CGFloat = LitterFont.conversationCodePointSize
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
@@ -20,8 +20,12 @@ struct CodeBlockView: View {
                     .litterMonoFont(size: fontSize)
                     .foregroundColor(LitterTheme.textBody)
                     .textSelection(.enabled)
+                    // Let the text keep its natural width inside the horizontal
+                    // scroller. A max-width frame here asks SwiftUI to squeeze
+                    // long source lines, which produces ellipses instead of a
+                    // scrollable code block.
+                    .fixedSize(horizontal: true, vertical: true)
                     .padding(12)
-                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .background(LitterTheme.codeBackground.opacity(0.8))

--- a/apps/ios/Sources/Litter/Views/ConversationDisplayUITestHarnessView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationDisplayUITestHarnessView.swift
@@ -1,6 +1,56 @@
 import SwiftUI
+import os
+import Foundation
 
 #if DEBUG
+/// PERF-0a render-isolation counters (DEBUG-only). The four production
+/// signpost sites call `trace(site, rowID:)` so the DEBUG harness can assert
+/// which surfaces/rows re-evaluate under a deterministic delta.
+/// Preserve through PERF-1.
+@MainActor
+enum RenderIsolationCounters {
+    enum Site {
+        static let timelineRow = "TimelineRow"
+        static let sessionRow = "SessionRow"
+        static let header = "Header"
+        static let homeCard = "HomeCard"
+    }
+
+    static let signpostLog = OSLog(
+        subsystem: "com.sigkitten.litter",
+        category: "RenderIsolation"
+    )
+
+    private(set) static var totals: [String: Int] = [:]
+    private(set) static var rows: [String: [String: Int]] = [:]
+    private(set) static var epoch: Int = 0
+
+    @discardableResult
+    static func trace(_ site: String, rowID: String? = nil) -> Int {
+        os_signpost(.event, log: signpostLog, name: "BodyEval", "%{public}s|%{public}s", site, rowID ?? "-")
+        totals[site, default: 0] += 1
+        if let rowID {
+            rows[site, default: [:]][rowID, default: 0] += 1
+        }
+        return totals[site] ?? 0
+    }
+
+    static func reset() {
+        totals = [:]
+        rows = [:]
+        epoch += 1
+    }
+
+    static var json: String {
+        let payload: [String: Any] = ["epoch": epoch, "totals": totals, "rows": rows]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]),
+              let json = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return json
+    }
+}
+
 struct ConversationDisplayUITestHarnessView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(AppState.self) private var appState
@@ -14,6 +64,11 @@ struct ConversationDisplayUITestHarnessView: View {
     @State private var composerSelection = NSRange(location: 0, length: 0)
     @State private var showAttachMenu = false
     @State private var voiceManager = VoiceTranscriptionManager()
+    @State private var fixtureItems: [ConversationItem] = []
+    @State private var fixtureSessions: [AppSessionSummary] = []
+    @State private var fixturesLoaded = false
+    @State private var publishedCountersJSON = "{}"
+    @State private var navigationPath: [String] = []
 
     static var isEnabled: Bool {
         ProcessInfo.processInfo.arguments.contains("--ui-test-conversation-display")
@@ -23,65 +78,25 @@ struct ConversationDisplayUITestHarnessView: View {
         ProcessInfo.processInfo.arguments.contains("--ui-test-open-settings")
     }
 
+    private static var fixtureTimestamp: Date {
+        Date(timeIntervalSince1970: 1_700_000_000)
+    }
+
+    private static var isMidhistoryScenario: Bool {
+        (ProcessInfo.processInfo.environment["CODEXIOS_UI_TEST_SCENARIO"] ?? "") == "midhistory-tool-result"
+    }
+
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    Text("Conversation Display Test")
-                        .litterFont(.title3, weight: .semibold)
-                        .foregroundColor(LitterTheme.textPrimary)
-                        .accessibilityIdentifier("conversationDisplayHarness.title")
-
-                    ConversationComposerEntryRowView(
-                        showAttachMenu: $showAttachMenu,
-                        inputText: $composerText,
-                        isComposerFocused: $composerFocused,
-                        composerSelectionRange: $composerSelection,
-                        voiceManager: voiceManager,
-                        isTurnActive: false,
-                        hasAttachment: false,
-                        modelLabel: ProcessInfo.processInfo.environment["CODEXIOS_UI_TEST_MODEL_LABEL"] ?? "GPT-5",
-                        reasoningLabel: "high",
-                        collaborationMode: .default,
-                        showModeChip: true,
-                        onPasteImage: { _ in },
-                        onSendText: {},
-                        onStopRecording: {},
-                        onStartRecording: {},
-                        onInterrupt: {}
-                    )
-
-                    ConversationTurnTimeline(
-                        items: Self.seedItems,
-                        isLive: false,
-                        serverId: "ui-test-server",
-                        originThreadId: nil,
-                        agentDirectoryVersion: 0,
-                        messageActionsDisabled: true,
-                        onStreamingSnapshotRendered: nil,
-                        onLiveContentLayoutChanged: nil,
-                        resolveTargetLabel: { _ in nil },
-                        onWidgetPrompt: { _ in },
-                        onEditUserItem: { _ in },
-                        onForkFromUserItem: { _ in }
-                    )
-                    .accessibilityIdentifier("conversationDisplayHarness.timeline")
-                }
-                .padding(16)
-            }
-            .background(LitterTheme.backgroundGradient.ignoresSafeArea())
-            .navigationTitle("Display Harness")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        showSettings = true
-                    } label: {
-                        Image(systemName: "gearshape")
+        let environment = ProcessInfo.processInfo.environment
+        let sessionCount = Self.sessionCount(from: environment)
+        NavigationStack(path: $navigationPath) {
+            if sessionCount > 0 {
+                sessionsRoot
+                    .navigationDestination(for: String.self) { _ in
+                        conversationDetail
                     }
-                    .accessibilityLabel("Settings")
-                    .accessibilityIdentifier("conversationDisplayHarness.settingsButton")
-                }
+            } else {
+                conversationDetail
             }
         }
         .sheet(isPresented: $showSettings) {
@@ -92,12 +107,170 @@ struct ConversationDisplayUITestHarnessView: View {
         }
         .onAppear {
             applyLaunchDisplayModes()
+            if !fixturesLoaded {
+                fixtureItems = Self.generatedItems(environment: environment)
+                fixtureSessions = Self.generatedSessionSummaries(environment: environment)
+                fixturesLoaded = true
+            }
             if Self.opensSettingsOnLaunch {
                 DispatchQueue.main.async {
                     showSettings = true
                 }
             }
         }
+    }
+
+    private var sessionsRoot: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(fixtureSessions.enumerated()), id: \.element.key) { index, session in
+                    SessionRowView(
+                        thread: session,
+                        isActive: false,
+                        parent: nil,
+                        hasTurnActive: false,
+                        updatedAtText: "2d ago",
+                        isResuming: false,
+                        depth: 0,
+                        hasChildren: false,
+                        isCollapsed: false,
+                        lineage: nil,
+                        onToggleNode: {},
+                        onSelectSession: {
+                            navigationPath.append(session.key.threadId)
+                        }
+                    )
+                    .accessibilityElement(children: .combine)
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityIdentifier("harness.sessionRow-\(index)")
+                }
+            }
+            .accessibilityIdentifier("harness.sessionsList")
+        }
+        .navigationTitle("Sessions Harness")
+        .navigationBarTitleDisplayMode(.inline)
+        .overlay(alignment: .bottom) { harnessControls }
+    }
+
+    private var conversationDetail: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Conversation Display Test")
+                    .litterFont(.title3, weight: .semibold)
+                    .foregroundColor(LitterTheme.textPrimary)
+                    .accessibilityIdentifier("conversationDisplayHarness.title")
+
+                ConversationComposerEntryRowView(
+                    showAttachMenu: $showAttachMenu,
+                    inputText: $composerText,
+                    isComposerFocused: $composerFocused,
+                    composerSelectionRange: $composerSelection,
+                    voiceManager: voiceManager,
+                    isTurnActive: false,
+                    hasAttachment: false,
+                    modelLabel: ProcessInfo.processInfo.environment["CODEXIOS_UI_TEST_MODEL_LABEL"] ?? "GPT-5",
+                    reasoningLabel: "high",
+                    collaborationMode: .default,
+                    showModeChip: true,
+                    onPasteImage: { _ in },
+                    onSendText: {},
+                    onStopRecording: {},
+                    onStartRecording: {},
+                    onInterrupt: {}
+                )
+
+                ConversationTurnTimeline(
+                    items: fixtureItems,
+                    isLive: Self.isMidhistoryScenario,
+                    serverId: "ui-test-server",
+                    originThreadId: nil,
+                    agentDirectoryVersion: 0,
+                    messageActionsDisabled: true,
+                    onStreamingSnapshotRendered: nil,
+                    onLiveContentLayoutChanged: nil,
+                    resolveTargetLabel: { _ in nil },
+                    onWidgetPrompt: { _ in },
+                    onEditUserItem: { _ in },
+                    onForkFromUserItem: { _ in }
+                )
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier("conversationDisplayHarness.timeline")
+            }
+            .padding(16)
+        }
+        .background(LitterTheme.backgroundGradient.ignoresSafeArea())
+        .overlay(alignment: .bottom) { harnessControls }
+        .navigationTitle("Display Harness")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showSettings = true
+                } label: {
+                    Image(systemName: "gearshape")
+                }
+                .accessibilityLabel("Settings")
+                .accessibilityIdentifier("conversationDisplayHarness.settingsButton")
+            }
+        }
+    }
+
+    private var harnessControls: some View {
+        HStack(spacing: 4) {
+            Text("render counters")
+                .font(.system(size: 1))
+                .accessibilityIdentifier("harness.bodyEvalCounts")
+                .accessibilityValue(Text(publishedCountersJSON))
+
+            Button("reset") {
+                RenderIsolationCounters.reset()
+                publishedCountersJSON = "{}"
+            }
+            .accessibilityIdentifier("harness.resetCounters")
+            .font(.system(size: 8))
+            .frame(width: 20, height: 20)
+
+            Button("publish") {
+                publishedCountersJSON = RenderIsolationCounters.json
+            }
+            .accessibilityIdentifier("harness.publishCounters")
+            .font(.system(size: 8))
+            .frame(width: 20, height: 20)
+
+            Button("stream") {
+                streamBatch()
+            }
+            .accessibilityIdentifier("harness.streamBatch")
+            .font(.system(size: 8))
+            .frame(width: 20, height: 20)
+
+            Button("tool") {
+                completeMidhistoryTool()
+            }
+            .accessibilityIdentifier("harness.completeMidhistoryTool")
+            .font(.system(size: 8))
+            .frame(width: 20, height: 20)
+        }
+        .padding(4)
+        .background(LitterTheme.surface.opacity(0.4))
+    }
+
+    private func streamBatch() {
+        guard let idx = fixtureItems.lastIndex(where: \.isAssistantItem) else { return }
+        guard case .assistant(var data) = fixtureItems[idx].content else { return }
+        for i in 0..<20 {
+            data.text += " delta-\(i)"
+        }
+        fixtureItems[idx].content = .assistant(data)
+    }
+
+    private func completeMidhistoryTool() {
+        guard let idx = fixtureItems.firstIndex(where: { $0.id == "mh-tool-K" }) else { return }
+        guard case .commandExecution(var data) = fixtureItems[idx].content else { return }
+        data.status = .completed
+        data.output = "ui-test tool result K"
+        data.exitCode = 0
+        fixtureItems[idx].content = .commandExecution(data)
     }
 
     private func applyLaunchDisplayModes() {
@@ -115,7 +288,121 @@ struct ConversationDisplayUITestHarnessView: View {
         return rawValue
     }
 
-    private static let seedItems: [ConversationItem] = [
+    // MARK: - Deterministic fixture generation (no Date()/random)
+
+    private static func sessionCount(from environment: [String: String]) -> Int {
+        guard let raw = environment["CODEXIOS_UI_TEST_SESSION_COUNT"],
+              let count = Int(raw), count > 0 else {
+            return 0
+        }
+        return count
+    }
+
+    /// ITEM_COUNT applies only when explicitly set; unset env returns the
+    /// canonical six items byte-for-byte. Scenario overrides everything.
+    private static func generatedItems(environment: [String: String]) -> [ConversationItem] {
+        let scenario = environment["CODEXIOS_UI_TEST_SCENARIO"] ?? ""
+        let itemCount = environment["CODEXIOS_UI_TEST_ITEM_COUNT"].flatMap { Int($0) }
+        if scenario == "midhistory-tool-result" {
+            guard let count = itemCount, count > 7 else {
+                return midhistoryItems()
+            }
+            let canonical = midhistoryItems()
+            let pattern = (0..<(count - canonical.count)).map { patternItem(at: $0) }
+            return pattern + canonical
+        }
+        guard let count = itemCount, count > 0 else {
+            return canonicalSeedItems
+        }
+        return (0..<count).map { patternItem(at: $0) }
+    }
+
+    private static func generatedSessionSummaries(environment: [String: String]) -> [AppSessionSummary] {
+        let count = sessionCount(from: environment)
+        guard count > 0 else { return [] }
+        var sessions: [AppSessionSummary] = []
+        sessions.reserveCapacity(count)
+        for i in 0..<count {
+            sessions.append(sessionSummary(at: i))
+        }
+        return sessions
+    }
+
+    private static func sessionSummary(at index: Int) -> AppSessionSummary {
+        let threadId = "ui-test-session-\(index)"
+        return AppSessionSummary(
+            key: ThreadKey(serverId: "ui-test-server", threadId: threadId),
+            agentRuntimeKind: .codex,
+            serverDisplayName: "UI Test Server",
+            serverHost: "ui-test.local",
+            title: "UI Test Session \(index)",
+            preview: "ui-test preview \(index)",
+            cwd: "/tmp/ui-test-\(index)",
+            model: "",
+            modelProvider: "",
+            parentThreadId: nil,
+            forkedFromId: nil,
+            agentNickname: nil,
+            agentRole: nil,
+            agentDisplayLabel: threadId,
+            agentStatus: .unknown,
+            updatedAt: Int64(1_700_000_000 - index),
+            hasActiveTurn: false,
+            isResumed: false,
+            isSubagent: false,
+            isFork: false,
+            lastResponsePreview: nil,
+            lastResponseTurnId: nil,
+            lastUserMessage: nil,
+            lastToolLabel: nil,
+            recentToolLog: [],
+            lastTurnStartMs: nil,
+            lastTurnEndMs: nil,
+            stats: nil,
+            tokenUsage: nil,
+            goal: nil
+        )
+    }
+
+    /// Mid-history tool-result scenario (corpus-derived shapes, deterministic).
+    /// T1 done, T2 done + tool `mh-tool-K` running, T3 streaming. Corpus:
+    /// `…/v2.0.1/perf-0a/corpus/05-tool-file-order.json`
+    /// (sha256 c126251a51590d29b0c39530e5899d27a63160ef0d31a87ea0feff2b4c93556a).
+    private static func midhistoryItems() -> [ConversationItem] {
+        let t = fixtureTimestamp
+        return [
+            ConversationItem(id: "mh-u1", content: .user(ConversationUserMessageData(text: "MIDHISTORY_USER_T1", images: [])), timestamp: t, isFromUserTurnBoundary: true),
+            ConversationItem(id: "mh-a1", content: .assistant(ConversationAssistantMessageData(text: "MIDHISTORY_ASSISTANT_T1", agentNickname: nil, agentRole: nil, phase: nil)), timestamp: t),
+            ConversationItem(id: "mh-u2", content: .user(ConversationUserMessageData(text: "MIDHISTORY_USER_T2", images: [])), timestamp: t, isFromUserTurnBoundary: true),
+            ConversationItem(id: "mh-a2", content: .assistant(ConversationAssistantMessageData(text: "MIDHISTORY_ASSISTANT_T2", agentNickname: nil, agentRole: nil, phase: nil)), timestamp: t),
+            ConversationItem(id: "mh-tool-K", content: .commandExecution(ConversationCommandExecutionData(command: "ui-test command K", cwd: "/tmp", status: .inProgress, output: nil, exitCode: nil, durationMs: nil, processId: nil, actions: [])), timestamp: t),
+            ConversationItem(id: "mh-u3", content: .user(ConversationUserMessageData(text: "MIDHISTORY_USER_T3", images: [])), timestamp: t, isFromUserTurnBoundary: true),
+            ConversationItem(id: "mh-a3", content: .assistant(ConversationAssistantMessageData(text: "MIDHISTORY_ASSISTANT_T3_STREAM", agentNickname: nil, agentRole: nil, phase: nil)), timestamp: t)
+        ]
+    }
+
+    /// Deterministic pattern item for large fixtures (generic id `ui-test-item-{i}`).
+    private static func patternItem(at index: Int) -> ConversationItem {
+        let t = fixtureTimestamp
+        switch index % 6 {
+        case 0:
+            return ConversationItem(id: "ui-test-item-\(index)", content: .user(ConversationUserMessageData(text: "UITEST_PATTERN_USER_\(index)", images: [])), timestamp: t, isFromUserTurnBoundary: true)
+        case 1:
+            return ConversationItem(id: "ui-test-item-\(index)", content: .assistant(ConversationAssistantMessageData(text: "UITEST_PATTERN_ASSISTANT_\(index)", agentNickname: nil, agentRole: nil, phase: nil)), timestamp: t)
+        case 2:
+            return ConversationItem(id: "ui-test-item-\(index)", content: .reasoning(ConversationReasoningData(summary: ["UITEST_PATTERN_REASONING_\(index)"], content: [])), timestamp: t)
+        case 3:
+            return ConversationItem(id: "ui-test-item-\(index)", content: .commandExecution(ConversationCommandExecutionData(command: "printf UITEST_PATTERN_COMMAND_\(index)", cwd: "/tmp", status: .completed, output: "UITEST_PATTERN_OUTPUT_\(index)", exitCode: 0, durationMs: 25, processId: nil, actions: [])), timestamp: t)
+        case 4:
+            return ConversationItem(id: "ui-test-item-\(index)", content: .mcpToolCall(ConversationMcpToolCallData(server: "uiTest", tool: "fixtureTool\(index)", status: .completed, durationMs: 30, argumentsJSON: "{\"fixture\":\"UITEST_PATTERN_TOOL_\(index)\"}", contentSummary: "UITEST_PATTERN_TOOL_DETAIL_\(index)", structuredContentJSON: nil, rawOutputJSON: nil, errorMessage: nil, progressMessages: [], computerUse: nil)), timestamp: t)
+        default:
+            return ConversationItem(id: "ui-test-item-\(index)", content: .commandExecution(ConversationCommandExecutionData(command: "sleep 10 && echo UITEST_PATTERN_LIVE_\(index)", cwd: "/tmp", status: .inProgress, output: "UITEST_PATTERN_LIVE_OUTPUT_\(index)", exitCode: nil, durationMs: nil, processId: nil, actions: [])), timestamp: t)
+        }
+    }
+
+    /// Canonical six-item seed — byte-for-byte identical to the pre-PERF-0a
+    /// `seedItems` (existing display UITests depend on the exact items).
+    private static let canonicalSeedItems: [ConversationItem] = [
         ConversationItem(
             id: "ui-test-user",
             content: .user(ConversationUserMessageData(

--- a/apps/ios/Sources/Litter/Views/ConversationDisplayUITestHarnessView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationDisplayUITestHarnessView.swift
@@ -126,7 +126,16 @@ struct ConversationDisplayUITestHarnessView: View {
         ConversationItem(
             id: "ui-test-assistant",
             content: .assistant(ConversationAssistantMessageData(
-                text: "UITEST_ASSISTANT_MESSAGE",
+                text: """
+                ## UITEST_ASSISTANT_MESSAGE
+
+                Here is a short answer with `inline code`, readable prose, and a second paragraph so typography and spacing are visible in screenshots.
+
+                ```swift
+                let greeting = "UITEST_CODE_BLOCK"
+                print(greeting)
+                ```
+                """,
                 agentNickname: nil,
                 agentRole: nil,
                 phase: nil

--- a/apps/ios/Sources/Litter/Views/ConversationScreenModel.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationScreenModel.swift
@@ -141,6 +141,9 @@ final class ConversationScreenModel {
     }
 
     private func refreshState() {
+        #if DEBUG
+        let refreshSignpostID = PerfAttribution.begin("RefreshState"); defer { PerfAttribution.end("RefreshState", refreshSignpostID) }
+        #endif
         guard let thread, let appModel else {
             transcript = .empty
             pinnedContextItems = []
@@ -302,6 +305,9 @@ private struct ProjectedConversationItemsResult {
 
 private extension ConversationScreenModel {
     func projectConversationItems(from hydratedItems: [HydratedConversationItem]) -> ProjectedConversationItemsResult {
+        #if DEBUG
+        let projectSignpostID = PerfAttribution.begin("ProjectItems"); defer { PerfAttribution.end("ProjectItems", projectSignpostID) }
+        #endif
         let previousHydratedItems = cachedHydratedConversationItems
         if previousHydratedItems == hydratedItems {
             return ProjectedConversationItemsResult(

--- a/apps/ios/Sources/Litter/Views/ConversationTimelineView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationTimelineView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import HairballUI
 import UIKit
+import os
 
 struct ConversationTurnTimeline: View {
     @AppStorage(ConversationDisplayPreferenceKey.reasoning) private var reasoningDisplayModeRaw = ConversationDetailDisplayMode.collapsed.rawValue
@@ -417,6 +418,9 @@ private struct ConversationTimelineItemRow: View, Equatable {
     // Time Profiler on 2026-04-18 showed that union's `outlined destroy` +
     // witness-table accessor accounting for ~49% of main-thread CPU on device.
     var body: AnyView {
+        #if DEBUG
+        RenderIsolationCounters.trace(RenderIsolationCounters.Site.timelineRow, rowID: item.id)
+        #endif
         switch item.content {
         case .user(let data):
             return AnyView(userRow(data))

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -636,6 +636,9 @@ private struct ConversationMessageList: View {
 
     private var sourceTurns: [TranscriptTurn] {
         if transcriptTurns.isEmpty {
+            #if DEBUG
+            os_signpost(.event, log: PerfAttribution.log, name: "TurnBuildInBody")
+            #endif
             return TranscriptTurn.build(
                 from: items,
                 threadStatus: threadStatus,
@@ -967,6 +970,9 @@ private struct ConversationMessageList: View {
             return
         }
 
+        #if DEBUG
+        let turnBuildSignpostID = PerfAttribution.begin("TurnBuild"); defer { PerfAttribution.end("TurnBuild", turnBuildSignpostID) }
+        #endif
         let nextTurns = TranscriptTurn.build(
             from: items,
             threadStatus: threadStatus,
@@ -1570,6 +1576,12 @@ private struct ConversationInputBar: View {
         #if targetEnvironment(macCatalyst)
         .onReceive(NotificationCenter.default.publisher(for: .litterCommandSendComposer)) { _ in
             handleSend()
+        }
+        #endif
+        #if DEBUG
+        .onReceive(NotificationCenter.default.publisher(for: .litterDebugBurstFire)) { note in
+            guard let key = note.userInfo?["key"] as? ThreadKey, key == snapshot.threadKey, let text = note.userInfo?["text"] as? String else { return }
+            inputText = text; handleSend()
         }
         #endif
         .onDisappear {
@@ -3323,7 +3335,7 @@ struct QueuedFollowUpsPreviewView: View {
                     .clipShape(Capsule())
             }
 
-            ForEach(previews, id: \.id) { preview in
+            ForEach(Array(previews.enumerated()), id: \.element.id) { index, preview in
                 let style = QueuedFollowUpPreviewStyle.forKind(preview.kind)
 
                 HStack(alignment: .center, spacing: 12) {
@@ -3369,6 +3381,7 @@ struct QueuedFollowUpsPreviewView: View {
                             .clipShape(Capsule())
                         }
                         .buttonStyle(.plain)
+                        .accessibilityIdentifier("conversation.queuedFollowUp-\(index).steer")
                         .disabled(preview.kind == .pendingSteer)
                     }
 
@@ -3379,6 +3392,7 @@ struct QueuedFollowUpsPreviewView: View {
                             .frame(width: 30, height: 30)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityIdentifier("conversation.queuedFollowUp-\(index).delete")
                 }
                 .padding(12)
                 .background(style.background)
@@ -3387,11 +3401,13 @@ struct QueuedFollowUpsPreviewView: View {
                         .stroke(style.border, lineWidth: 1)
                 )
                 .clipShape(RoundedRectangle(cornerRadius: 14))
+                .accessibilityIdentifier("conversation.queuedFollowUp-\(index)")
             }
         }
         .padding(12)
         .background(LitterTheme.codeBackground.opacity(0.92))
         .clipShape(RoundedRectangle(cornerRadius: 14))
+        .accessibilityIdentifier("conversation.queuedFollowUps")
     }
 }
 

--- a/apps/ios/Sources/Litter/Views/HeaderView.swift
+++ b/apps/ios/Sources/Litter/Views/HeaderView.swift
@@ -1,5 +1,6 @@
 import SafariServices
 import SwiftUI
+import os
 
 struct HeaderView: View {
     @Environment(AppState.self) private var appState
@@ -28,6 +29,9 @@ struct HeaderView: View {
     }
 
     var body: some View {
+        #if DEBUG
+        let _ = RenderIsolationCounters.trace(RenderIsolationCounters.Site.header)
+        #endif
         Button {
             appState.showModelSelector.toggle()
         } label: {

--- a/apps/ios/Sources/Litter/Views/HomeDashboardModel.swift
+++ b/apps/ios/Sources/Litter/Views/HomeDashboardModel.swift
@@ -231,6 +231,9 @@ final class HomeDashboardModel {
     }
 
     private func refreshState() {
+        #if DEBUG
+        let deriveSignpostID = PerfAttribution.begin("HomeDerive"); defer { PerfAttribution.end("HomeDerive", deriveSignpostID) }
+        #endif
         guard isActive, let appModel else {
             connectedServers = []
             recentSessions = []

--- a/apps/ios/Sources/Litter/Views/HomeDashboardView.swift
+++ b/apps/ios/Sources/Litter/Views/HomeDashboardView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import os
 
 /// Which chrome layer the dashboard renders with.
 ///
@@ -729,6 +730,13 @@ struct SessionCanvasLine: View {
     // ────────────────────────────────────────────────────
 
     var body: some View {
+        #if DEBUG
+        // PERF-0a HomeCard proxy: SessionCanvasLine is instantiated once per
+        // session by HomeSessionRowContent (HomeSessionsScrollView.swift, out of
+        // scope). Caveats: (a) undercounts outer-chrome-only re-evals;
+        // (b) PiPContentView also instantiates it — PERF-0b must keep PiP off.
+        let _ = RenderIsolationCounters.trace(RenderIsolationCounters.Site.homeCard)
+        #endif
         HStack(alignment: .top, spacing: 0) {
             Group {
                 if isOpening {

--- a/apps/ios/Sources/Litter/Views/MessageBubbleView.swift
+++ b/apps/ios/Sources/Litter/Views/MessageBubbleView.swift
@@ -46,7 +46,7 @@ struct LitterMarkdownView: View {
     let markdown: String
     var style: LitterMarkdownStyleVariant = .content
     var bodySize: CGFloat = LitterFont.conversationBodyPointSize
-    var codeSize: CGFloat = LitterFont.conversationBodyPointSize
+    var codeSize: CGFloat = LitterFont.conversationCodePointSize
     var selectionEnabled = true
 
     @State private var debugSettings = DebugSettings.shared
@@ -99,7 +99,7 @@ struct InlineSelectableMarkdownMessage<Content: View>: View {
     let markdown: String
     var style: LitterMarkdownStyleVariant = .content
     var bodySize: CGFloat = LitterFont.conversationBodyPointSize
-    var codeSize: CGFloat = LitterFont.conversationBodyPointSize
+    var codeSize: CGFloat = LitterFont.conversationCodePointSize
     @ViewBuilder let content: () -> Content
 
     var body: some View {
@@ -292,7 +292,7 @@ struct AssistantBubble: View, Equatable {
                     markdown: markdownString,
                     style: .content,
                     bodySize: contentFontSize,
-                    codeSize: contentFontSize
+                    codeSize: LitterFont.conversationCodePointSize
                 ) {
                     bubbleContent
                 }
@@ -316,7 +316,7 @@ struct AssistantBubble: View, Equatable {
                 markdown: markdownString,
                 style: .content,
                 bodySize: contentFontSize,
-                codeSize: contentFontSize
+                codeSize: LitterFont.conversationCodePointSize
             )
             .fixedSize(horizontal: false, vertical: true)
             .transaction { $0.animation = nil }
@@ -361,7 +361,7 @@ struct AssistantBlocksBubble: View {
                 markdown: content,
                 style: .content,
                 bodySize: contentFontSize,
-                codeSize: contentFontSize
+                codeSize: LitterFont.conversationCodePointSize
             )
             .frame(maxWidth: .infinity, alignment: .leading)
             .id(identity)
@@ -374,7 +374,7 @@ struct AssistantBlocksBubble: View {
                 CodeBlockView(
                     language: language ?? "",
                     code: code,
-                    fontSize: contentFontSize
+                    fontSize: LitterFont.conversationCodePointSize
                 )
                 .id(identity)
             }
@@ -406,7 +406,7 @@ private struct LitterMathBlockView: View {
     var body: some View {
         ScrollView(.horizontal, showsIndicators: true) {
             LatexBlockView(content: latex)
-                .fixedSize(horizontal: true, vertical: false)
+                    .fixedSize(horizontal: true, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -497,7 +497,7 @@ struct StreamingAssistantBubble: View {
                         .revealGranularity(typingConfig.effectiveGranularity)
                         .litterContentMarkdown(
                             bodySize: contentFontSize,
-                            codeSize: contentFontSize,
+                            codeSize: LitterFont.conversationCodePointSize,
                             selectionEnabled: !isStreaming
                         )
                         .transaction { $0.animation = nil }
@@ -506,7 +506,7 @@ struct StreamingAssistantBubble: View {
                         markdown: text,
                         style: .content,
                         bodySize: contentFontSize,
-                        codeSize: contentFontSize
+                        codeSize: LitterFont.conversationCodePointSize
                     )
                     .fixedSize(horizontal: false, vertical: true)
                     .tokenReveal(.disabled)
@@ -529,8 +529,12 @@ private func litterContentTheme(bodySize: CGFloat, codeSize: CGFloat) -> Markdow
     // primary foreground rather than the muted metadata color so long replies
     // retain contrast on dark themes.
     theme.foregroundColor = LitterTheme.textPrimary
-    theme.paragraphSpacing = 8
-    theme.blockSpacing = 8
+    // Hairball's default 1.6 multiplier reads overly airy in a long mobile
+    // transcript. Keep enough leading for scanning while making consecutive
+    // paragraphs feel like one answer rather than isolated cards.
+    theme.lineSpacing = 1.36
+    theme.paragraphSpacing = 10
+    theme.blockSpacing = 10
 
     theme.headingStyleSet = HeadingStyleSet(
         h1: HeadingStyle(font: LitterFont.markdownHeadingFont(size: bodySize * 1.43, weight: .bold), fontSize: bodySize * 1.43, weight: .bold,
@@ -603,8 +607,9 @@ private func litterSystemTheme(bodySize: CGFloat, codeSize: CGFloat) -> Markdown
     theme.bodyFont = LitterFont.markdownBodyFont(size: bodySize)
     theme.bodyFontSize = bodySize
     theme.foregroundColor = LitterTheme.textSystem
-    theme.paragraphSpacing = 6
-    theme.blockSpacing = 6
+    theme.lineSpacing = 1.32
+    theme.paragraphSpacing = 8
+    theme.blockSpacing = 8
 
     theme.headingStyleSet = HeadingStyleSet(
         h1: HeadingStyle(font: LitterFont.markdownHeadingFont(size: bodySize * 1.31, weight: .bold), fontSize: bodySize * 1.31, weight: .bold,
@@ -704,7 +709,29 @@ struct LitterCodeBlockRenderer: CodeBlockRenderer {
             .modifier(GlassRectModifier(cornerRadius: 8))
             .modifier(CodeBlockTerminalContextMenu(code: configuration.code))
         } else {
-            DefaultCodeBlockRenderer().makeBody(configuration: configuration)
+            VStack(alignment: .leading, spacing: 0) {
+                if configuration.hasLanguage {
+                    HStack {
+                        Text(configuration.languageDisplayName)
+                            .litterMonoFont(size: 11, weight: .semibold)
+                            .foregroundColor(LitterTheme.textSecondary)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.top, 8)
+                    .padding(.bottom, 4)
+                }
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    Text(configuration.highlightedCode)
+                        .font(configuration.theme.codeBlock.font)
+                        .foregroundColor(configuration.theme.codeBlock.textColor)
+                        .fixedSize(horizontal: true, vertical: true)
+                        .padding(configuration.theme.codeBlock.padding)
+                }
+            }
+            .background(configuration.theme.codeBlock.backgroundColor)
+            .clipShape(RoundedRectangle(cornerRadius: configuration.theme.codeBlock.cornerRadius))
                 .modifier(GlassRectModifier(cornerRadius: 8))
                 .modifier(CodeBlockTerminalContextMenu(code: configuration.code))
         }
@@ -895,7 +922,7 @@ private struct ScaledSystemMarkdownModifier: ViewModifier {
 extension View {
     func litterContentMarkdown(
         bodySize: CGFloat = LitterFont.conversationBodyPointSize,
-        codeSize: CGFloat = LitterFont.conversationBodyPointSize,
+        codeSize: CGFloat = LitterFont.conversationCodePointSize,
         selectionEnabled: Bool = true
     ) -> some View {
         modifier(
@@ -909,7 +936,7 @@ extension View {
 
     func litterSystemMarkdown(
         bodySize: CGFloat = LitterFont.conversationBodyPointSize,
-        codeSize: CGFloat = LitterFont.conversationBodyPointSize,
+        codeSize: CGFloat = LitterFont.conversationCodePointSize,
         selectionEnabled: Bool = true
     ) -> some View {
         modifier(

--- a/apps/ios/Sources/Litter/Views/SessionsModel.swift
+++ b/apps/ios/Sources/Litter/Views/SessionsModel.swift
@@ -58,6 +58,9 @@ final class SessionsModel {
     }
 
     private func refreshState() {
+        #if DEBUG
+        let deriveSignpostID = PerfAttribution.begin("SessionsDerive"); defer { PerfAttribution.end("SessionsDerive", deriveSignpostID) }
+        #endif
         guard let appModel, let appState else {
             derivedData = .empty
             connectedServerOptions = []

--- a/apps/ios/Sources/Litter/Views/SessionsScreen.swift
+++ b/apps/ios/Sources/Litter/Views/SessionsScreen.swift
@@ -837,119 +837,20 @@ struct SessionsScreen: View {
         onToggleNode: @escaping () -> Void,
         onSelectSession: @escaping () -> Void
     ) -> some View {
-        let parent = derived.parentByKey[thread.key]
-        let hasTurnActive = ephemeralState?.hasTurnActive ?? thread.hasActiveTurn
-        let updatedAt = ephemeralState?.updatedAt ?? thread.updatedAtDate
-
-        return VStack(alignment: .leading, spacing: 4) {
-            HStack(alignment: .top, spacing: 6) {
-                HStack(spacing: 0) {
-                    Color.clear
-                        .frame(width: CGFloat(depth) * 8)
-                    if hasChildren {
-                        Button(action: onToggleNode) {
-                            Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
-                                .litterFont(size: 9, weight: .semibold)
-                                .foregroundColor(LitterTheme.textSecondary)
-                                .frame(width: 10, height: 10)
-                        }
-                        .buttonStyle(.plain)
-                    } else {
-                        Color.clear.frame(width: 10, height: 10)
-                    }
-                }
-                .padding(.top, 2)
-
-                HStack(alignment: .top, spacing: 6) {
-                    if hasTurnActive {
-                        PulsingDot().padding(.top, 3)
-                    } else if thread.isSubagent {
-                        subagentStatusIndicator(thread.subagentStatus).padding(.top, 3)
-                    } else {
-                        Circle().fill(LitterTheme.textMuted.opacity(0.4)).frame(width: 8, height: 8).padding(.top, 3)
-                    }
-
-                    VStack(alignment: .leading, spacing: 3) {
-                        HStack(alignment: .firstTextBaseline, spacing: 6) {
-                            FormattedText(text: thread.sessionTitle, lineLimit: 2)
-                                .litterFont(.footnote)
-                                .foregroundColor(LitterTheme.textPrimary)
-                                .multilineTextAlignment(.leading)
-                                .accessibilityIdentifier("sessions.sessionTitle")
-
-                            if thread.isSubagent {
-                                HStack(spacing: 3) {
-                                    Image(systemName: "person.2.fill")
-                                        .litterFont(size: 8, weight: .semibold)
-                                    Text(thread.agentDisplayLabel ?? "Agent")
-                                        .litterFont(.caption2)
-                                }
-                                .foregroundColor(LitterTheme.textOnAccent)
-                                .padding(.horizontal, 5)
-                                .padding(.vertical, 2)
-                                .background(LitterTheme.success)
-                                .cornerRadius(4)
-                            } else if thread.isFork {
-                                Text("Fork")
-                                    .litterFont(.caption2)
-                                    .foregroundColor(LitterTheme.textOnAccent)
-                                    .padding(.horizontal, 5)
-                                    .padding(.vertical, 2)
-                                    .background(LitterTheme.accent)
-                                    .cornerRadius(4)
-                            }
-
-                            Spacer(minLength: 0)
-
-                            if resumingKey == thread.key {
-                                ProgressView()
-                                    .controlSize(.small)
-                                    .tint(LitterTheme.accent)
-                            }
-                        }
-
-                        HStack(spacing: 4) {
-                            Text(relativeDate(updatedAt))
-                                .foregroundColor(LitterTheme.textSecondary)
-                            if let provider = thread.sessionModelLabel {
-                                Text("•")
-                                    .foregroundColor(LitterTheme.textMuted)
-                                Text(provider)
-                                    .foregroundColor(LitterTheme.textMuted)
-                            }
-                            if let parent {
-                                Text("•")
-                                    .foregroundColor(LitterTheme.textMuted)
-                                Text("from \(parent.sessionTitle)")
-                                    .foregroundColor(LitterTheme.textMuted)
-                            }
-                        }
-                        .litterFont(.caption2)
-                        .lineLimit(1)
-                    }
-                }
-                .contentShape(Rectangle())
-                .accessibilityElement(children: .combine)
-                .accessibilityAddTraits(.isButton)
-                .accessibilityIdentifier("sessions.sessionRow")
-                .onTapGesture(perform: onSelectSession)
-            }
-
-            if isActive {
-                lineageSummary(for: thread, derived: derived)
-            }
-        }
-        .padding(.leading, 1)
-        .padding(.trailing, 8)
-        .padding(.vertical, 5)
-        .background {
-            if isActive {
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(LitterTheme.surfaceLight.opacity(0.55))
-            }
-        }
-        .contentShape(Rectangle())
-        .hoverEffect(.highlight)
+        SessionRowView(
+            thread: thread,
+            isActive: isActive,
+            parent: derived.parentByKey[thread.key],
+            hasTurnActive: ephemeralState?.hasTurnActive ?? thread.hasActiveTurn,
+            updatedAtText: relativeDate(ephemeralState?.updatedAt ?? thread.updatedAtDate),
+            isResuming: resumingKey == thread.key,
+            depth: depth,
+            hasChildren: hasChildren,
+            isCollapsed: isCollapsed,
+            lineage: isActive ? AnyView(lineageSummary(for: thread, derived: derived)) : nil,
+            onToggleNode: onToggleNode,
+            onSelectSession: onSelectSession
+        )
     }
 
     private func lineageSummary(for thread: AppSessionSummary, derived: SessionsDerivedData) -> some View {
@@ -1016,36 +917,6 @@ struct SessionsScreen: View {
                     .stroke(isInteractive ? LitterTheme.accent.opacity(0.5) : LitterTheme.border.opacity(0.5), lineWidth: 1)
             )
             .cornerRadius(5)
-    }
-
-    @ViewBuilder
-    private func subagentStatusIndicator(_ status: AppSubagentStatus) -> some View {
-        switch status {
-        case .completed:
-            Image(systemName: "checkmark.circle.fill")
-                .litterFont(size: 8)
-                .foregroundColor(LitterTheme.success)
-                .frame(width: 8, height: 8)
-        case .errored:
-            Image(systemName: "exclamationmark.circle.fill")
-                .litterFont(size: 8)
-                .foregroundColor(LitterTheme.danger)
-                .frame(width: 8, height: 8)
-        case .shutdown:
-            Image(systemName: "stop.circle.fill")
-                .litterFont(size: 8)
-                .foregroundColor(LitterTheme.textMuted)
-                .frame(width: 8, height: 8)
-        case .interrupted:
-            Image(systemName: "pause.circle.fill")
-                .litterFont(size: 8)
-                .foregroundColor(LitterTheme.warning)
-                .frame(width: 8, height: 8)
-        case .pendingInit, .running, .unknown:
-            Circle()
-                .fill(LitterTheme.textMuted.opacity(0.4))
-                .frame(width: 8, height: 8)
-        }
     }
 
     private func visibleSessionRows(for group: WorkspaceSessionGroup) -> [SessionTreeRow] {
@@ -1337,6 +1208,169 @@ struct SessionsScreen: View {
 
     private func relativeDate(_ date: Date) -> String {
         Self.relativeFormatter.localizedString(for: date, relativeTo: Date())
+    }
+}
+
+/// Internal row view extracted from `SessionsScreen.sessionRow` so the DEBUG
+/// PERF-0a harness can mount the real session row (pixel-identical). Preamble
+/// values and the lineage slot are pre-resolved by the caller.
+struct SessionRowView: View {
+    let thread: AppSessionSummary
+    let isActive: Bool
+    let parent: AppSessionSummary?
+    let hasTurnActive: Bool
+    let updatedAtText: String
+    let isResuming: Bool
+    let depth: Int
+    let hasChildren: Bool
+    let isCollapsed: Bool
+    let lineage: AnyView?
+    let onToggleNode: () -> Void
+    let onSelectSession: () -> Void
+
+    var body: some View {
+        #if DEBUG
+        let _ = RenderIsolationCounters.trace(RenderIsolationCounters.Site.sessionRow, rowID: "\(thread.key.serverId)/\(thread.key.threadId)")
+        #endif
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .top, spacing: 6) {
+                HStack(spacing: 0) {
+                    Color.clear
+                        .frame(width: CGFloat(depth) * 8)
+                    if hasChildren {
+                        Button(action: onToggleNode) {
+                            Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
+                                .litterFont(size: 9, weight: .semibold)
+                                .foregroundColor(LitterTheme.textSecondary)
+                                .frame(width: 10, height: 10)
+                        }
+                        .buttonStyle(.plain)
+                    } else {
+                        Color.clear.frame(width: 10, height: 10)
+                    }
+                }
+                .padding(.top, 2)
+
+                HStack(alignment: .top, spacing: 6) {
+                    if hasTurnActive {
+                        PulsingDot().padding(.top, 3)
+                    } else if thread.isSubagent {
+                        subagentStatusIndicator(thread.subagentStatus).padding(.top, 3)
+                    } else {
+                        Circle().fill(LitterTheme.textMuted.opacity(0.4)).frame(width: 8, height: 8).padding(.top, 3)
+                    }
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(alignment: .firstTextBaseline, spacing: 6) {
+                            FormattedText(text: thread.sessionTitle, lineLimit: 2)
+                                .litterFont(.footnote)
+                                .foregroundColor(LitterTheme.textPrimary)
+                                .multilineTextAlignment(.leading)
+                                .accessibilityIdentifier("sessions.sessionTitle")
+
+                            if thread.isSubagent {
+                                HStack(spacing: 3) {
+                                    Image(systemName: "person.2.fill")
+                                        .litterFont(size: 8, weight: .semibold)
+                                    Text(thread.agentDisplayLabel ?? "Agent")
+                                        .litterFont(.caption2)
+                                }
+                                .foregroundColor(LitterTheme.textOnAccent)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 2)
+                                .background(LitterTheme.success)
+                                .cornerRadius(4)
+                            } else if thread.isFork {
+                                Text("Fork")
+                                    .litterFont(.caption2)
+                                    .foregroundColor(LitterTheme.textOnAccent)
+                                    .padding(.horizontal, 5)
+                                    .padding(.vertical, 2)
+                                    .background(LitterTheme.accent)
+                                    .cornerRadius(4)
+                            }
+
+                            Spacer(minLength: 0)
+
+                            if isResuming {
+                                ProgressView()
+                                    .controlSize(.small)
+                                    .tint(LitterTheme.accent)
+                            }
+                        }
+
+                        HStack(spacing: 4) {
+                            Text(updatedAtText)
+                                .foregroundColor(LitterTheme.textSecondary)
+                            if let provider = thread.sessionModelLabel {
+                                Text("•")
+                                    .foregroundColor(LitterTheme.textMuted)
+                                Text(provider)
+                                    .foregroundColor(LitterTheme.textMuted)
+                            }
+                            if let parent {
+                                Text("•")
+                                    .foregroundColor(LitterTheme.textMuted)
+                                Text("from \(parent.sessionTitle)")
+                                    .foregroundColor(LitterTheme.textMuted)
+                            }
+                        }
+                        .litterFont(.caption2)
+                        .lineLimit(1)
+                    }
+                }
+                .contentShape(Rectangle())
+                .accessibilityElement(children: .combine)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityIdentifier("sessions.sessionRow")
+                .onTapGesture(perform: onSelectSession)
+            }
+
+            if let lineage {
+                lineage
+            }
+        }
+        .padding(.leading, 1)
+        .padding(.trailing, 8)
+        .padding(.vertical, 5)
+        .background {
+            if isActive {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(LitterTheme.surfaceLight.opacity(0.55))
+            }
+        }
+        .contentShape(Rectangle())
+        .hoverEffect(.highlight)
+    }
+
+    @ViewBuilder
+    private func subagentStatusIndicator(_ status: AppSubagentStatus) -> some View {
+        switch status {
+        case .completed:
+            Image(systemName: "checkmark.circle.fill")
+                .litterFont(size: 8)
+                .foregroundColor(LitterTheme.success)
+                .frame(width: 8, height: 8)
+        case .errored:
+            Image(systemName: "exclamationmark.circle.fill")
+                .litterFont(size: 8)
+                .foregroundColor(LitterTheme.danger)
+                .frame(width: 8, height: 8)
+        case .shutdown:
+            Image(systemName: "stop.circle.fill")
+                .litterFont(size: 8)
+                .foregroundColor(LitterTheme.textMuted)
+                .frame(width: 8, height: 8)
+        case .interrupted:
+            Image(systemName: "pause.circle.fill")
+                .litterFont(size: 8)
+                .foregroundColor(LitterTheme.warning)
+                .frame(width: 8, height: 8)
+        case .pendingInit, .running, .unknown:
+            Circle()
+                .fill(LitterTheme.textMuted.opacity(0.4))
+                .frame(width: 8, height: 8)
+        }
     }
 }
 

--- a/apps/ios/Tests/LitterTests/AppSnapshotRuntimeTests.swift
+++ b/apps/ios/Tests/LitterTests/AppSnapshotRuntimeTests.swift
@@ -552,3 +552,120 @@ final class AppSnapshotRuntimeTests: XCTestCase {
         )
     }
 }
+
+#if DEBUG
+extension AppSnapshotRuntimeTests {
+    private func grammarEnv(_ input: String) -> [String: String] { ["CODEXIOS_UI_TEST_BURST_FOLLOWUPS": "1", "CODEXIOS_UI_TEST_BURST_NONCE": input] }
+    @MainActor
+    func testDebugProductionFixtureShapeIsExactAndDeterministic() {
+        let snapshot = DebugProductionFixture.makeSnapshot(sessions: 300, items: 1500)
+        XCTAssertEqual(snapshot, DebugProductionFixture.makeSnapshot(sessions: 300, items: 1500), "independent construction must be identical")
+        XCTAssertEqual(snapshot.threads.count, 300); XCTAssertEqual(snapshot.sessionSummaries.count, 300)
+        XCTAssertEqual(Set(snapshot.threads.compactMap(\.info.cwd)), Set((0..<12).map { "/Projects/Workspace-\($0)" }))
+        XCTAssertEqual(snapshot.threads[9].info.parentThreadId, "fixture-thread-0")
+        let items = snapshot.threads[0].hydratedConversationItems
+        XCTAssertEqual(items.count, 1500)
+        XCTAssertEqual(items[749], DebugProductionFixture.item(at: 749), "thread-0 items must follow the 6-case pattern")
+        XCTAssertEqual(items[1].id, "fixture-item-1")
+        XCTAssertEqual(snapshot.threads[1].key, DebugProductionFixture.liveThreadKey)
+    }
+    @MainActor
+    func testBurstInputGrammarVectorsAndFullRejectionTable() throws {
+        let vectors: [(input: String, trial: String, attempt: String, steer: Bool, f2: String)] = [
+            ("B7.1-PLAIN-9af3c2", "7", "1", false, "Follow-up two B7.1-F2-9af3c2: reply with exactly BRAVO."),
+            ("B12.2-STEER-00ffee", "12", "2", true, "Follow-up two B12.2-F2-00ffee: reply with exactly BRAVO-STEERED."),
+            ("B901.1-STEER-0c0ffe", "901", "1", true, "Follow-up two B901.1-F2-0c0ffe: reply with exactly BRAVO-STEERED."),
+            ("B15.1-PLAIN-abc123", "15", "1", false, "Follow-up two B15.1-F2-abc123: reply with exactly BRAVO.")
+        ]
+        for v in vectors {
+            let config = try XCTUnwrap(DebugBurstDriver.configuration(environment: grammarEnv(v.input)))
+            XCTAssertEqual(config.trial, v.trial); XCTAssertEqual(config.attempt, v.attempt); XCTAssertEqual(config.mode, v.steer ? .steer : .plain)
+            XCTAssertEqual(DebugBurstDriver.wireNonce(config, fire: 2), "B\(v.trial).\(v.attempt)-F2-\(v.input.suffix(6))")
+            XCTAssertEqual(DebugBurstDriver.followUpTexts(configuration: config)[1], v.f2)
+        }
+        let v1 = try XCTUnwrap(DebugBurstDriver.configuration(environment: grammarEnv("B7.1-PLAIN-9af3c2")))
+        XCTAssertEqual(DebugBurstDriver.followUpTexts(configuration: v1), [
+            "Follow-up one B7.1-F1-9af3c2: reply with exactly ALPHA.",
+            "Follow-up two B7.1-F2-9af3c2: reply with exactly BRAVO.",
+            "Follow-up three B7.1-F3-9af3c2: reply with exactly CHARLIE."
+        ])
+        let v2 = try XCTUnwrap(DebugBurstDriver.configuration(environment: grammarEnv("B12.2-STEER-00ffee")))
+        XCTAssertEqual((1...3).map { DebugBurstDriver.wireNonce(v2, fire: $0) }, ["B12.2-F1-00ffee", "B12.2-F2-00ffee", "B12.2-F3-00ffee"])
+        XCTAssertEqual(DebugBurstDriver.followUpTexts(configuration: v2), ["Follow-up one B12.2-F1-00ffee: reply with exactly ALPHA.", "Follow-up two B12.2-F2-00ffee: reply with exactly BRAVO-STEERED.", "Follow-up three B12.2-F3-00ffee: reply with exactly CHARLIE."])
+        XCTAssertEqual(DebugBurstDriver.followUpTexts(configuration: try XCTUnwrap(DebugBurstDriver.configuration(environment: grammarEnv("B12.2-STEER-00ffee")))), DebugBurstDriver.followUpTexts(configuration: v2), "V5: fresh parse yields byte-identical texts")
+        let rejections = ["B7.1-F2-9af3c2", "B7.1-9af3c2", "B7.1-plain-9af3c2", "B7.1-Steer-9af3c2", "B7.1-PLAIN-9AF3C2", "b7.1-PLAIN-9af3c2", "B07.1-PLAIN-9af3c2", "B7.0-PLAIN-9af3c2", "B7.1-PLAIN-9af3c", "B7.1-PLAIN-9af3c2d", "B7.1-PLAIN-9af3g2", "B7.1-PLAIN-STEER-9af3c2", " B7.1-PLAIN-9af3c2", "B7.1-PLAIN-9af3c2\t"]
+        for input in rejections {
+            XCTAssertNil(DebugBurstDriver.configuration(environment: grammarEnv(input)))
+            XCTAssertEqual(DebugBurstDriver.rejectLine("malformed-nonce", value: input), "burst.driver reject reason=malformed-nonce value=\"\(input)\"")
+        }
+        XCTAssertEqual(DebugBurstDriver.rejectLine("missing-nonce"), "burst.driver reject reason=missing-nonce")
+        XCTAssertNil(DebugBurstDriver.configuration(environment: ["CODEXIOS_UI_TEST_BURST_FOLLOWUPS": "1"]), "followups armed + absent nonce: exactly one missing-nonce reject")
+        XCTAssertNil(DebugBurstDriver.configuration(environment: grammarEnv("")), "followups armed + empty nonce: exactly one missing-nonce reject")
+    }
+
+    @MainActor
+    func testBurstTimingParsingIsPositionalAndAlwaysReturnsThreeOffsets() {
+        XCTAssertEqual(DebugBurstDriver.parseTimings(nil), DebugBurstDriver.defaultOffsetsMs)
+        XCTAssertEqual(DebugBurstDriver.parseTimings(" 250 "), [250, 400, 700])
+        XCTAssertEqual(DebugBurstDriver.parseTimings("0,-5"), [10, 10, 700])
+        XCTAssertEqual(DebugBurstDriver.parseTimings("5,3000,100"), [10, 2000, 100])
+        XCTAssertEqual(DebugBurstDriver.parseTimings("100,200,300,400"), [100, 200, 300])
+        XCTAssertEqual(DebugBurstDriver.parseTimings("200,abc,700"), [200, 400, 700], "malformed slot keeps its position and defaults")
+        XCTAssertEqual(DebugBurstDriver.parseTimings("200,,700"), [200, 400, 700], "empty slot keeps its position and defaults")
+        XCTAssertEqual(DebugBurstDriver.parseTimings(",250,"), [200, 250, 700])
+        XCTAssertEqual(DebugBurstDriver.checkpointDelayMs(lastFireOffsetMs: 700, commandWindowMs: 8_000), 16_000)
+        XCTAssertEqual(DebugBurstDriver.checkpointDelayMs(lastFireOffsetMs: 700, commandWindowMs: 20_000), 28_000)
+        XCTAssertEqual(DebugBurstDriver.burstPlan(offsetsMs: [200, 400, 700], anchorMs: 10_000).map(\.intendedMs), [10_200, 10_400, 10_700])
+    }
+    @MainActor
+    func testBurstDriverArmLatchIsOneShotAndRecursionGuarded() throws {
+        let appModel = AppModel(); let driver = DebugBurstDriver()
+        driver.armIfRequested(environment: [:], appModel: appModel)
+        XCTAssertEqual(driver.phase, .idle)
+        driver.armIfRequested(environment: grammarEnv("B1.1-PLAIN-abc123"), appModel: appModel)
+        XCTAssertEqual(driver.phase, .armed)
+        let key = DebugProductionFixture.liveThreadKey
+        driver.noteStartTurnEntered(key: key, text: DebugBurstDriver.anchorPrompt + " ")
+        XCTAssertEqual(driver.phase, .armed, "near-miss anchor text must not fire")
+        XCTAssertFalse(driver.noteStartTurnEntered(key: key, text: DebugBurstDriver.anchorPrompt), "live anchor never short-circuits startTurn; the real pipeline runs")
+        XCTAssertEqual(driver.phase, .fired)
+        XCTAssertEqual(driver.scheduledFireCount, 3, "default offsets schedule exactly F1/F2/F3")
+        driver.armIfRequested(environment: grammarEnv("B2.1-PLAIN-def456"), appModel: appModel)
+        XCTAssertEqual(driver.phase, .fired, "one-shot latch must never re-arm")
+        var longEnv = grammarEnv("B29.1-PLAIN-feed42"); longEnv["CODEXIOS_UI_TEST_PRODUCTION_FIXTURE"] = "1"
+        let long = DebugBurstDriver(); long.armIfRequested(environment: longEnv, appModel: appModel); XCTAssertTrue(long.noteStartTurnEntered(key: key, text: DebugBurstDriver.anchorPromptLong), "fixture T0-LONG anchor short-circuits"); XCTAssertEqual(long.phase, .fired)
+        let texts = DebugBurstDriver.followUpTexts(configuration: try XCTUnwrap(DebugBurstDriver.configuration(environment: grammarEnv("B1.1-PLAIN-abc123"))))
+        for text in texts { driver.noteStartTurnEntered(key: key, text: text) }
+        XCTAssertEqual(driver.scheduledFireCount, 3, "driver-fired follow-ups never recursively schedule more fires")
+    }
+    @MainActor
+    func testIngressLedgerCapDropHeaderAndResetAccounting() {
+        let model = AppModel()
+        for i in 0..<520 { model.debugAppendLedger("e\(i)") }
+        XCTAssertEqual(model.debugIngressLedger.count, 512); XCTAssertEqual(model.debugIngressDropped, 8)
+        XCTAssertEqual(model.debugFlushIngressLedger(reason: "test"), "burst.ledger flush reason=test entries=512 dropped=8")
+        XCTAssertEqual(model.debugIngressLedger.count, 0); XCTAssertEqual(model.debugIngressDropped, 0)
+        XCTAssertNil(model.debugFlushIngressLedger(reason: "empty"))
+    }
+    @MainActor
+    func testFixtureAnchorShortCircuitsStartTurnAndRoutesBurstStreamToThread0Item1() async throws {
+        let model = AppModel()
+        model.applySnapshot(DebugProductionFixture.makeSnapshot(sessions: 300, items: 1500))
+        var env = grammarEnv("B1.1-PLAIN-abc123")
+        env["CODEXIOS_UI_TEST_BURST_TIMINGS_MS"] = "30,60,90"
+        env["CODEXIOS_UI_TEST_PRODUCTION_FIXTURE"] = "1"
+        XCTAssertTrue(model.debugArmBurstDriverIfRequested(environment: env))
+        let key = ThreadKey(serverId: DebugProductionFixture.serverId, threadId: "fixture-thread-0")
+        let foreignBefore = model.threadSnapshot(for: DebugProductionFixture.liveThreadKey)?.hydratedConversationItems.first { $0.id == DebugProductionFixture.liveAssistantItemId }
+        try await model.startTurn(key: key, payload: AppComposerPayload(text: DebugBurstDriver.anchorPrompt, additionalInputs: []))
+        try? await Task.sleep(nanoseconds: 800_000_000) // 30/60/90 ms fires land; the 1 s drain stays out
+        let thread0 = model.threadSnapshot(for: key)
+        XCTAssertEqual(thread0?.activeTurnId, "fixture-burst-turn")
+        XCTAssertEqual(thread0?.queuedFollowUps.count, 3)
+        guard case .assistant(let displayed)? = thread0?.hydratedConversationItems.first(where: { $0.id == "fixture-item-1" })?.content else { return XCTFail("thread-0 displayed stream item missing") }
+        XCTAssertTrue(displayed.text.contains("burst"), "thread-0 fixture-item-1 carries the displayed burst stream on the 1500-item route")
+        let foreignAfter = model.threadSnapshot(for: DebugProductionFixture.liveThreadKey)?.hydratedConversationItems.first { $0.id == DebugProductionFixture.liveAssistantItemId }
+        XCTAssertEqual(foreignAfter, foreignBefore, "foreign streaming stays distinct on thread-1's live assistant, untouched")
+    }
+}
+#endif

--- a/apps/ios/Tests/LitterTests/AppSnapshotRuntimeTests.swift
+++ b/apps/ios/Tests/LitterTests/AppSnapshotRuntimeTests.swift
@@ -334,6 +334,91 @@ final class AppSnapshotRuntimeTests: XCTestCase {
         XCTAssertEqual(key, ThreadKey(serverId: "srv", threadId: "thread-1"))
     }
 
+    @MainActor
+    func testR1SameThreadRebindOnStreamingDelta() async {
+        let appModel = AppModel()
+        let keyA = ThreadKey(serverId: "srv", threadId: "a")
+        let item = makeAssistantItem(id: "item-1", text: "hello")
+        appModel.applySnapshot(makeSnapshot(threads: [makeThreadSnapshotWithItem(key: keyA, item: item)]))
+        let baseline = appModel.threadRebindSignal(for: keyA).revision
+        await appModel._testHandleStoreUpdate(.threadStreamingDelta(key: keyA, itemId: "item-1", kind: .assistantText, text: " world"))
+        XCTAssertEqual(appModel.threadRebindSignal(for: keyA).revision, baseline + 1)
+    }
+    @MainActor
+    func testR2ForeignThreadIsolationOnStreamingDelta() async {
+        let appModel = AppModel()
+        let keyA = ThreadKey(serverId: "srv", threadId: "a"), keyB = ThreadKey(serverId: "srv", threadId: "b")
+        let item = makeAssistantItem(id: "item-1", text: "hello")
+        appModel.applySnapshot(makeSnapshot(threads: [makeThreadSnapshotWithItem(key: keyA, item: item), makeThreadSnapshotWithItem(key: keyB, item: item)]))
+        let baselineA = appModel.threadRebindSignal(for: keyA).revision, baselineGlobal = appModel.conversationGlobalRevision, baselineRevision = appModel.snapshotRevision
+        await appModel._testHandleStoreUpdate(.threadStreamingDelta(key: keyB, itemId: "item-1", kind: .assistantText, text: " world"))
+        XCTAssertEqual(appModel.threadRebindSignal(for: keyA).revision, baselineA)
+        XCTAssertEqual(appModel.conversationGlobalRevision, baselineGlobal)
+        XCTAssertGreaterThan(appModel.snapshotRevision, baselineRevision)
+    }
+    @MainActor
+    func testR3UnkeyedGlobalBumpOnPendingApprovals() async {
+        let appModel = AppModel()
+        let keyA = ThreadKey(serverId: "srv", threadId: "a"), keyB = ThreadKey(serverId: "srv", threadId: "b")
+        appModel.applySnapshot(makeSnapshot(threads: [makeThreadSnapshot(key: keyA), makeThreadSnapshot(key: keyB)]))
+        let baselineGlobal = appModel.conversationGlobalRevision, baselineA = appModel.threadRebindSignal(for: keyA).revision, baselineB = appModel.threadRebindSignal(for: keyB).revision
+        var snap = appModel.snapshot!
+        snap.pendingApprovals = [PendingApproval(id: "appr-1", serverId: "srv", kind: .command, threadId: nil, turnId: nil, itemId: nil, command: "ls", path: nil, grantRoot: nil, cwd: nil, reason: "test")]
+        appModel.applySnapshot(snap)
+        XCTAssertEqual(appModel.conversationGlobalRevision, baselineGlobal + 1)
+        XCTAssertEqual(appModel.threadRebindSignal(for: keyA).revision, baselineA)
+        XCTAssertEqual(appModel.threadRebindSignal(for: keyB).revision, baselineB)
+    }
+    @MainActor
+    func testR4SummaryOnlyWriteBumpsNothing() async {
+        let appModel = AppModel()
+        let keyA = ThreadKey(serverId: "srv", threadId: "a")
+        let item = makeAssistantItem(id: "item-1", text: "hello")
+        appModel.applySnapshot(makeSnapshot(threads: [makeThreadSnapshotWithItem(key: keyA, item: item)]))
+        let baselineSignal = appModel.threadRebindSignal(for: keyA).revision, baselineGlobal = appModel.conversationGlobalRevision, baselineRevision = appModel.snapshotRevision
+        var summary = appModel.snapshot!.sessionSummaries.first { $0.key == keyA }!
+        summary.title = "Updated"
+        await appModel._testHandleStoreUpdate(.threadItemChanged(key: keyA, item: item, sessionSummary: summary))
+        XCTAssertEqual(appModel.threadRebindSignal(for: keyA).revision, baselineSignal)
+        XCTAssertEqual(appModel.conversationGlobalRevision, baselineGlobal)
+        XCTAssertGreaterThan(appModel.snapshotRevision, baselineRevision)
+    }
+    @MainActor
+    func testR5RemovalRetainsSignalEntryAndMonotonicCount() async {
+        let appModel = AppModel()
+        let keyA = ThreadKey(serverId: "srv", threadId: "a"), keyB = ThreadKey(serverId: "srv", threadId: "b")
+        appModel.applySnapshot(makeSnapshot(threads: [makeThreadSnapshot(key: keyA), makeThreadSnapshot(key: keyB)]))
+        let signalB = appModel.threadRebindSignal(for: keyB)
+        let baselineA = appModel.threadRebindSignal(for: keyA).revision
+        await appModel._testHandleStoreUpdate(.threadRemoved(key: keyB, agentDirectoryVersion: 1))
+        XCTAssertEqual(appModel.threadRebindSignal(for: keyA).revision, baselineA)
+        XCTAssertTrue(appModel.threadRebindSignal(for: keyB) === signalB)
+        let afterRemoval = appModel.threadRebindSignal(for: keyB).revision
+        let reborn = makeThreadSnapshot(key: keyB)
+        var summary = appModel.snapshot!.sessionSummaries.first { $0.key == keyB } ?? makeSnapshot(threads: [reborn]).sessionSummaries[0]
+        summary.title = "Reborn"
+        await appModel._testHandleStoreUpdate(.threadUpserted(thread: reborn, sessionSummary: summary, agentDirectoryVersion: 1))
+        XCTAssertEqual(appModel.threadRebindSignal(for: keyB).revision, afterRemoval + 1)
+        XCTAssertTrue(appModel.threadRebindSignal(for: keyB) === signalB)
+    }
+    @MainActor
+    func testR6ActiveThreadNilBumpsGlobalNotScoped() async {
+        let appModel = AppModel()
+        let keyA = ThreadKey(serverId: "srv", threadId: "a")
+        appModel.applySnapshot(makeSnapshot(threads: [makeThreadSnapshot(key: keyA)]))
+        let baselineGlobal = appModel.conversationGlobalRevision, baselineA = appModel.threadRebindSignal(for: keyA).revision
+        await appModel._testHandleStoreUpdate(.activeThreadChanged(key: nil))
+        XCTAssertEqual(appModel.conversationGlobalRevision, baselineGlobal + 1)
+        XCTAssertEqual(appModel.threadRebindSignal(for: keyA).revision, baselineA)
+    }
+    private func makeAssistantItem(id: String, text: String) -> HydratedConversationItem {
+        HydratedConversationItem(id: id, content: .assistant(HydratedAssistantMessageData(text: text, agentNickname: nil, agentRole: nil, phase: nil)), sourceTurnId: nil, sourceTurnIndex: nil, timestamp: nil, isFromUserTurnBoundary: false)
+    }
+    private func makeThreadSnapshotWithItem(key: ThreadKey, item: HydratedConversationItem) -> AppThreadSnapshot {
+        var thread = makeThreadSnapshot(key: key)
+        thread.hydratedConversationItems = [item]
+        return thread
+    }
     private func makeSnapshot(threads: [AppThreadSnapshot]) -> AppSnapshotRecord {
         let server = AppServerSnapshot(
             serverId: "srv",

--- a/apps/ios/Tests/LitterTests/HomeDashboardSupportTests.swift
+++ b/apps/ios/Tests/LitterTests/HomeDashboardSupportTests.swift
@@ -389,6 +389,75 @@ final class HomeDashboardSupportTests: XCTestCase {
         XCTAssertGreaterThan(model.rebuildCount, rebuildCountBeforeDeactivate)
     }
 
+    func testSessionsDerivationBuildPerformance_100_300_1000() {
+        let fixtures: [Int: [AppSessionSummary]] = [
+            100: makeSessionSummaries(count: 100),
+            300: makeSessionSummaries(count: 300),
+            1000: makeSessionSummaries(count: 1000)
+        ]
+        measure(metrics: [XCTClockMetric()]) {
+            for count in [100, 300, 1000] {
+                _ = MainActor.assumeIsolated {
+                    SessionsDerivation.build(
+                        sessions: fixtures[count] ?? [],
+                        selectedServerFilterId: nil,
+                        showOnlyForks: false,
+                        selectedRuntimeKind: nil,
+                        workspaceSortMode: .mostRecent,
+                        searchQuery: "",
+                        frozenMostRecentOrder: nil
+                    )
+                }
+            }
+        }
+    }
+
+    private func makeSessionSummaries(count: Int) -> [AppSessionSummary] {
+        (0..<count).map { index in
+            let thread = makeThreadSnapshot(
+                serverId: "server-a",
+                threadId: "perf-session-\(index)",
+                updatedAt: TimeInterval(1_000_000 - index)
+            )
+            return AppSessionSummary(
+                key: thread.key,
+                agentRuntimeKind: thread.agentRuntimeKind,
+                serverDisplayName: "Server A",
+                serverHost: "server-a.local",
+                title: thread.info.title ?? "",
+                preview: thread.info.preview ?? "",
+                cwd: thread.info.cwd ?? "",
+                model: thread.model ?? "",
+                modelProvider: thread.info.modelProvider ?? "",
+                parentThreadId: thread.info.parentThreadId,
+                forkedFromId: nil,
+                agentNickname: thread.info.agentNickname,
+                agentRole: thread.info.agentRole,
+                agentDisplayLabel: AgentLabelFormatter.format(
+                    nickname: thread.info.agentNickname,
+                    role: thread.info.agentRole,
+                    fallbackIdentifier: thread.key.threadId
+                ),
+                agentStatus: .unknown,
+                updatedAt: thread.info.updatedAt,
+                hasActiveTurn: thread.hasActiveTurn,
+                isResumed: false,
+                isSubagent: thread.info.parentThreadId != nil,
+                isFork: thread.info.parentThreadId != nil,
+                lastResponsePreview: nil,
+                lastResponseTurnId: nil,
+                lastUserMessage: nil,
+                lastToolLabel: nil,
+                recentToolLog: [],
+                lastTurnStartMs: nil,
+                lastTurnEndMs: nil,
+                stats: nil,
+                tokenUsage: nil,
+                goal: nil
+            )
+        }
+    }
+
     private func makeThreadSnapshot(
         serverId: String,
         threadId: String,

--- a/apps/ios/Tests/LitterTests/LitterAppearanceModeTests.swift
+++ b/apps/ios/Tests/LitterTests/LitterAppearanceModeTests.swift
@@ -34,12 +34,12 @@ final class FontFamilyOptionTests: XCTestCase {
         ])
     }
 
-    func testChatGPTAndReaderChoicesUseProportionalFamilies() {
+    func testSystemAndReaderChoicesUseProportionalFamilies() {
         XCTAssertFalse(FontFamilyOption.system.isMono)
         XCTAssertFalse(FontFamilyOption.serif.isMono)
         XCTAssertTrue(FontFamilyOption.mono.isMono)
         XCTAssertTrue(FontFamilyOption.systemMono.isMono)
-        XCTAssertEqual(FontFamilyOption.system.displayName, "ChatGPT (System)")
+        XCTAssertEqual(FontFamilyOption.system.displayName, "System UI")
     }
 
     func testFontPreferenceObserverAdvancesRevision() {

--- a/apps/ios/Tests/LitterUITests/LitterUITests.swift
+++ b/apps/ios/Tests/LitterUITests/LitterUITests.swift
@@ -154,6 +154,176 @@ final class LitterUITests: XCTestCase {
         }
     }
 
+    // MARK: - PERF-0a deterministic perf tests
+
+    @MainActor
+    func testBodyEvaluationCountAt1500() throws {
+        let app = midhistoryHarnessApp()
+        app.launch()
+
+        XCTAssertTrue(app.otherElements["conversationDisplayHarness.timeline"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["UITEST_PATTERN_USER_0"].waitForExistence(timeout: 10))
+
+        // Mount liveness: publish once before any reset and assert the
+        // timeline mounted at least one row (guards against a vacuous zero).
+        app.buttons["harness.publishCounters"].tap()
+        var counters = readCounters(in: app)
+        let initialEpoch = counters["epoch"] as? Int ?? 0
+        let initialTotals = (counters["totals"] as? [String: Int]) ?? [:]
+        XCTAssertGreaterThanOrEqual(initialTotals["TimelineRow"] ?? 0, 1, "timeline rows must mount")
+
+        // Phase 1: streaming delta batch. StreamingRendererCoordinator updates
+        // the streaming bubble BELOW ConversationTimelineItemRow's Equatable
+        // (assistant rows skip renderDigest), so no timeline row body may
+        // re-evaluate on a text delta. SessionRow/Header/HomeCard must be 0.
+        app.buttons["harness.resetCounters"].tap()
+        app.buttons["harness.streamBatch"].tap()
+        app.buttons["harness.publishCounters"].tap()
+
+        counters = readCounters(in: app)
+        var totals = (counters["totals"] as? [String: Int]) ?? [:]
+        var rows = (counters["rows"] as? [String: [String: Int]]) ?? [:]
+        let timelineRows = rows["TimelineRow"] ?? [:]
+        XCTAssertEqual(counters["epoch"] as? Int ?? 0, initialEpoch + 1, "epoch must advance on reset")
+        XCTAssertEqual(totals["TimelineRow"] ?? 0, 0)
+        XCTAssertEqual(totals["SessionRow"] ?? 0, 0)
+        XCTAssertEqual(totals["Header"] ?? 0, 0)
+        XCTAssertEqual(totals["HomeCard"] ?? 0, 0)
+        XCTAssertTrue(timelineRows.isEmpty, "no timeline row body may re-evaluate on a streaming delta: \(timelineRows)")
+
+        // Phase 2: mid-history tool completion — positive control. Exactly the
+        // tool row (mh-tool-K) re-evaluates (turn-state transition sample):
+        // target 1, binding ≤2, all other surfaces 0.
+        app.buttons["harness.resetCounters"].tap()
+        app.buttons["harness.completeMidhistoryTool"].tap()
+        app.buttons["harness.publishCounters"].tap()
+
+        counters = readCounters(in: app)
+        totals = (counters["totals"] as? [String: Int]) ?? [:]
+        rows = (counters["rows"] as? [String: [String: Int]]) ?? [:]
+        let toolTimelineRows = rows["TimelineRow"] ?? [:]
+        XCTAssertEqual(counters["epoch"] as? Int ?? 0, initialEpoch + 2, "epoch must advance on second reset")
+        XCTAssertEqual(totals["SessionRow"] ?? 0, 0)
+        XCTAssertEqual(toolTimelineRows.count, 1, "exactly one key expected: \(toolTimelineRows)")
+        let toolHits = toolTimelineRows["mh-tool-K"] ?? 0
+        XCTAssertGreaterThanOrEqual(toolHits, 1)
+        XCTAssertLessThanOrEqual(toolHits, 2)
+        XCTAssertEqual(totals["TimelineRow"] ?? 0, toolHits)
+        // Tool-result content visibility is proven by the dedicated 7-item
+        // `testMidhistoryToolCompletionRendersResult` (COMMAND_MODE=expanded);
+        // keep this 1500-item scale/counter gate free of a text assertion.
+    }
+
+    @MainActor
+    func testMidhistoryToolCompletionRendersResult() throws {
+        let app = XCUIApplication()
+        app.launchArguments.append("--ui-test-conversation-display")
+        app.launchEnvironment["CODEXIOS_UI_TEST_SCENARIO"] = "midhistory-tool-result"
+        app.launchEnvironment["CODEXIOS_UI_TEST_COMMAND_MODE"] = "expanded"
+        app.launch()
+
+        let toolButton = app.buttons["harness.completeMidhistoryTool"]
+        XCTAssertTrue(toolButton.waitForExistence(timeout: 10))
+        toolButton.tap()
+
+        let resultText = app.staticTexts["ui-test tool result K"]
+        if resultText.waitForExistence(timeout: 10) {
+            return
+        }
+
+        // Fallback: an existing combined command-row accessibility element
+        // whose label or value carries the rendered result.
+        let labelPredicate = NSPredicate(format: "label CONTAINS %@", "ui-test tool result K")
+        let valuePredicate = NSPredicate(format: "value CONTAINS %@", "ui-test tool result K")
+        let combined = app.descendants(matching: .any)
+            .matching(NSCompoundPredicate(orPredicateWithSubpredicates: [labelPredicate, valuePredicate]))
+            .firstMatch
+        if combined.waitForExistence(timeout: 5) {
+            return
+        }
+
+        XCTFail("Mid-history tool completion result is not accessible as a static text or combined command-row element")
+    }
+
+    @MainActor
+    func testConversationScrollPerformanceAt1500() throws {
+        let app = XCUIApplication()
+        app.launchArguments.append("--ui-test-conversation-display")
+        app.launchEnvironment["CODEXIOS_UI_TEST_ITEM_COUNT"] = "1500"
+        app.launch()
+
+        XCTAssertTrue(app.otherElements["conversationDisplayHarness.timeline"].waitForExistence(timeout: 15))
+
+        measure(metrics: [XCTOSSignpostMetric.scrollDecelerationMetric]) {
+            for _ in 0..<6 {
+                let start = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8))
+                let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2))
+                start.press(forDuration: 0.05, thenDragTo: end)
+            }
+        }
+    }
+
+    @MainActor
+    func testComposerKeystrokeLatency() throws {
+        let app = XCUIApplication()
+        app.launchArguments.append("--ui-test-conversation-display")
+        app.launch()
+
+        let composer = app.textViews["conversation.composerTextView"]
+        XCTAssertTrue(composer.waitForExistence(timeout: 10))
+        composer.tap()
+        measure(metrics: [XCTClockMetric()]) {
+            composer.typeText("PERF0A_TYPING_PROBE")
+        }
+    }
+
+    @MainActor
+    func testBackToListPerformanceAt300Sessions() throws {
+        let app = XCUIApplication()
+        app.launchArguments.append("--ui-test-conversation-display")
+        app.launchEnvironment["CODEXIOS_UI_TEST_SESSION_COUNT"] = "300"
+        app.launchEnvironment["CODEXIOS_UI_TEST_ITEM_COUNT"] = "1500"
+        app.launch()
+
+        let firstRow = app.buttons["harness.sessionRow-0"]
+        XCTAssertTrue(firstRow.waitForExistence(timeout: 20))
+        firstRow.tap()
+        XCTAssertTrue(app.navigationBars["Display Harness"].waitForExistence(timeout: 15))
+
+        measure(metrics: [XCTClockMetric()]) {
+            for _ in 0..<5 {
+                app.navigationBars.buttons.firstMatch.tap()
+                XCTAssertTrue(app.buttons["harness.sessionRow-0"].waitForExistence(timeout: 5))
+                app.buttons["harness.sessionRow-0"].tap()
+                XCTAssertTrue(app.navigationBars["Display Harness"].waitForExistence(timeout: 5))
+            }
+        }
+    }
+
+    @MainActor
+    private func midhistoryHarnessApp() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments.append("--ui-test-conversation-display")
+        app.launchEnvironment["CODEXIOS_UI_TEST_SCENARIO"] = "midhistory-tool-result"
+        app.launchEnvironment["CODEXIOS_UI_TEST_ITEM_COUNT"] = "1500"
+        app.launchEnvironment["CODEXIOS_UI_TEST_COMMAND_MODE"] = "expanded"
+        return app
+    }
+
+    @MainActor
+    private func readCounters(in app: XCUIApplication) -> [String: Any] {
+        let element = app.staticTexts["harness.bodyEvalCounts"]
+        XCTAssertTrue(element.waitForExistence(timeout: 5))
+        let raw = (element.value as? String) ?? "{}"
+        XCTAssertNotEqual(raw, "{}", "published counters JSON must not be the empty stub")
+        guard let data = raw.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            XCTFail("Could not decode counters JSON: \(raw)")
+            return [:]
+        }
+        return object
+    }
+
     @MainActor
     private func conversationDisplayHarnessApp(
         reasoning: String = "collapsed",

--- a/apps/ios/Tests/LitterUITests/LitterUITests.swift
+++ b/apps/ios/Tests/LitterUITests/LitterUITests.swift
@@ -25,6 +25,7 @@ final class LitterUITests: XCTestCase {
 
         XCTAssertTrue(app.staticTexts["UITEST_USER_MESSAGE"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.staticTexts["UITEST_ASSISTANT_MESSAGE"].exists)
+        XCTAssertTrue(app.staticTexts["UITEST_CODE_BLOCK"].exists)
         XCTAssertTrue(app.staticTexts["UITEST_REASONING_DETAIL"].exists)
         XCTAssertTrue(app.staticTexts["UITEST_COMMAND_OUTPUT"].exists)
         XCTAssertTrue(app.staticTexts["UITEST_TOOL_DETAIL"].exists)

--- a/apps/ios/Tests/LitterUITests/LitterUITests.swift
+++ b/apps/ios/Tests/LitterUITests/LitterUITests.swift
@@ -354,3 +354,126 @@ final class LitterUITests: XCTestCase {
         return false
     }
 }
+
+extension LitterUITests {
+    private func productionFixtureApp(streamForeign: Bool = false) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchEnvironment["CODEXIOS_UI_TEST_PRODUCTION_FIXTURE"] = "1" // env defaults: 300 sessions / 1500 items
+        if streamForeign { app.launchEnvironment["CODEXIOS_UI_TEST_STREAM_FOREIGN"] = "1" }
+        return app
+    }
+    private func openConversationThenSessions(_ app: XCUIApplication) {
+        let card = app.descendants(matching: .any).matching(identifier: "home.recentSessionCard").firstMatch
+        XCTAssertTrue(card.waitForExistence(timeout: 20), "fixture home dashboard must render recent session cards")
+        card.tap()
+        let composer = app.textViews["conversation.composerTextView"]
+        XCTAssertTrue(composer.waitForExistence(timeout: 20), "conversation must push from the home card")
+        composer.tap()
+        composer.typeText("/resume")
+        app.buttons["Send"].tap()
+        XCTAssertTrue(app.buttons["sessions.sessionRow"].firstMatch.waitForExistence(timeout: 10), "/resume must reveal the real SessionsScreen")
+    }
+    private func measureConversationCycle(enter: XCUIElement, revealed: XCUIElement, composer: XCUIElement, back: XCUIElement, route: String, warmUpSettle: TimeInterval = 0) {
+        func cycle(_ message: String, settle: TimeInterval) {
+            enter.tap()
+            XCTAssertTrue(composer.waitForExistence(timeout: 20), "conversation must open")
+            if settle > 0 { Thread.sleep(forTimeInterval: settle) } // open-time settling stays outside the measured iterations
+            back.tap()
+            XCTAssertTrue(revealed.waitForExistence(timeout: 10), message)
+        }
+        cycle(route, settle: warmUpSettle)
+        let options = XCTMeasureOptions()
+        options.iterationCount = 10
+        measure(metrics: [XCTOSSignpostMetric.navigationTransitionMetric, XCTClockMetric()], options: options) {
+            cycle(route, settle: 0)
+        }
+    }
+    private func sessionRow(containing text: String, in app: XCUIApplication) -> XCUIElement {
+        app.buttons.matching(identifier: "sessions.sessionRow").matching(NSPredicate(format: "label CONTAINS %@", text)).firstMatch
+    }
+    @MainActor
+    func testProductionBackToSessionsAt300() throws {
+        let app = productionFixtureApp()
+        app.launch()
+        openConversationThenSessions(app)
+        let composer = app.textViews["conversation.composerTextView"]
+        let back = app.buttons["Back"].firstMatch
+        let row = app.buttons["sessions.sessionRow"].firstMatch
+        measureConversationCycle(enter: row, revealed: row, composer: composer, back: back, route: "Back must reveal the real sessions list")
+        app.navigationBars.buttons.firstMatch.tap() // sessions -> home
+        let card = app.descendants(matching: .any).matching(identifier: "home.recentSessionCard").firstMatch
+        XCTAssertTrue(card.waitForExistence(timeout: 10))
+        measureConversationCycle(enter: card, revealed: card, composer: composer, back: back, route: "Back must remount the home dashboard")
+    }
+
+    @MainActor
+    func testProductionOpenConversationAt1500() throws {
+        let app = productionFixtureApp()
+        app.launch()
+        let card = app.descendants(matching: .any).matching(identifier: "home.recentSessionCard").firstMatch
+        XCTAssertTrue(card.waitForExistence(timeout: 20), "fixture home dashboard must render recent session cards")
+        measureConversationCycle(enter: card, revealed: card, composer: app.textViews["conversation.composerTextView"], back: app.buttons["Back"].firstMatch, route: "Back must return to the home card", warmUpSettle: 1.5)
+    }
+
+    @MainActor
+    func testProductionSessionsScrollAndSearchAt300() throws {
+        let app = productionFixtureApp()
+        app.launch()
+        openConversationThenSessions(app)
+        let start = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8))
+        let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2))
+        start.press(forDuration: 0.05, thenDragTo: end) // untimed warm-up fling
+        let options = XCTMeasureOptions()
+        options.iterationCount = 10
+        measure(metrics: [XCTOSSignpostMetric.scrollDecelerationMetric], options: options) {
+            start.press(forDuration: 0.05, thenDragTo: end) // one fling per iteration
+        }
+        let search = app.textFields["Search sessions"]
+        search.tap()
+        search.typeText("288") // untimed warm-up: type -> derived list stable
+        XCTAssertTrue(sessionRow(containing: "Fixture thread 288", in: app).waitForExistence(timeout: 5))
+        search.typeText("\u{8}\u{8}\u{8}") // clear the warm-up query
+        let cleared = expectation(for: NSPredicate(format: "value == ''"), evaluatedWith: search)
+        wait(for: [cleared], timeout: 5)
+        options.invocationOptions = [.manuallyStart, .manuallyStop]
+        measure(metrics: [XCTClockMetric()], options: options) {
+            self.startMeasuring()
+            search.typeText("299")
+            XCTAssertTrue(sessionRow(containing: "Fixture thread 299", in: app).waitForExistence(timeout: 5), "derived list must settle on the single match")
+            self.stopMeasuring()
+            search.typeText("\u{8}\u{8}\u{8}")
+            wait(for: [expectation(for: NSPredicate(format: "value == ''"), evaluatedWith: search)], timeout: 5)
+        }
+    }
+
+    @MainActor
+    func testProductionComposerTypingDuringForeignStream() throws {
+        let app = productionFixtureApp(streamForeign: true)
+        app.launch()
+        let card = app.descendants(matching: .any).matching(identifier: "home.recentSessionCard").firstMatch
+        XCTAssertTrue(card.waitForExistence(timeout: 20), "fixture home dashboard must render recent session cards")
+        card.tap()
+        let composer = app.textViews["conversation.composerTextView"]
+        XCTAssertTrue(composer.waitForExistence(timeout: 20), "conversation must push from the home card")
+        Thread.sleep(forTimeInterval: 2) // settle the open-time scroll chain and the first foreign deltas
+        composer.tap()
+        composer.typeText("PERF0A_TYPING_PROBE") // untimed warm-up typing pass
+        app.buttons["fixture.resetCounters"].tap()
+        let options = XCTMeasureOptions()
+        options.iterationCount = 10
+        measure(metrics: [XCTClockMetric()], options: options) {
+            composer.typeText("PERF0A_TYPING_PROBE") // the 19-character probe
+        }
+        app.buttons["fixture.publishCounters"].tap()
+        let readout = app.staticTexts["fixture.counterReadout"]
+        XCTAssertTrue(readout.waitForExistence(timeout: 5), "fixture counter readout must be published")
+        guard let counters = (try? JSONSerialization.jsonObject(with: Data(((readout.value as? String) ?? "{}").utf8))) as? [String: Any] else { return XCTFail("could not decode counter readout JSON") }
+        let totals = (counters["totals"] as? [String: Int]) ?? [:]
+        let timelineRows = (counters["rows"] as? [String: [String: Int]])?["TimelineRow"] ?? [:]
+        XCTAssertEqual(totals["TimelineRow"] ?? 0, 0, "foreign deltas must not re-evaluate any thread-0 TimelineRow: \(timelineRows)")
+        let attachment = XCTAttachment(string: "m3-s4 epoch=\(counters["epoch"] ?? -1) totals=\(totals)") // records SessionRow/HomeCard totals
+        attachment.name = "m3-s4-counter-totals"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/goal.md
+++ b/goal.md
@@ -1,0 +1,361 @@
+# Litter v2.0.1 Delivery Goal
+
+Last updated: 2026-08-14 19:08 EDT
+
+This file is the execution contract for Litter v2.0.1. It records what the user asked for, what is actually proven, what is still failing, and the order in which the remaining work must happen. A green build alone is not completion. The goal ends only after both stores are successfully deployed and obsolete work is safely removed.
+
+## Outcome
+
+Deliver one coherent Litter v2.0.1 release that:
+
+- contains every worthwhile change currently split across branches and pull requests;
+- makes long session lists, conversation loading, Back navigation, composing, streaming, and multi-turn follow-ups feel instant;
+- stops unrelated views and long lists from re-rendering on every update;
+- preserves all current iOS and Android functionality;
+- gives the composer a cleaner Codex-like layout and interaction model;
+- reduces tracked first-party code by at least 25% against the frozen `origin/main` baseline;
+- is fully tested on simulator/emulator and physical devices, with recordings, profiles, size evidence, and review;
+- lands as one mega PR with small logical commits;
+- is merged so local `main` and `origin/main` are identical;
+- is successfully deployed to Apple App Store/TestFlight and Google Play;
+- closes obsolete PRs and deletes dead branches/worktrees only after their useful work is captured and the release is proven.
+
+## User request ledger
+
+The following requests are all in scope and must not disappear during implementation:
+
+1. Inspect `origin`, determine the latest deployed app, and reconcile it with the app that was on the user's phone.
+2. Bring the authoritative result into local `main` without destroying divergent local work.
+3. Review the large line-reduction PR and keep only simplifications that preserve behavior.
+4. Reduce total first-party LOC by 25%, with functionality intact.
+5. Converge all valuable alpha work into one mega PR with logically separated commits.
+6. Close all other PRs and delete dead remote/local branches only after their useful work is captured.
+7. Delete outstanding worktrees only after final validation and only after proving they contain no uncaptured work.
+8. Test all production features and workflows on iOS and Android.
+9. Measure responsiveness, launch/session/conversation latency, scrolling, rendering, app size, and regressions.
+10. Use computer-driven UI testing and preserve recordings as evidence.
+11. Fix the global re-render problem that makes large project/session/folder lists slow.
+12. Make Back navigation from chat immediate, not multi-second.
+13. Make multi-turn conversations and rapid follow-up sends reliable, instant, and free of flicker.
+14. Make the composer remain responsive and focused during streaming and look more like Codex.
+15. Consult and aggregate Fable-5, GLM-5.3, Kimi-K3, and DeepSeek-V4-Pro; obtain a final Claude Code Opus-5 review.
+16. Install the latest fixed candidate on the user's iPhone.
+17. Finish by successfully deploying the same accepted release to both mobile stores.
+
+## Non-negotiable rules
+
+- `origin/main` is the shared source of truth.
+- Start and finish delivery on `main`; final local `main` and `origin/main` must resolve to the same commit.
+- Preserve existing dirty state. Do not reset, stash, overwrite, or delete another worktree's changes.
+- Shared session/thread/reducer/reconnect logic belongs in Rust when both platforms need it. Swift and Kotlin stay thin.
+- Every implementation change gets a small logical commit after its own validation.
+- Do not merge, deploy, close PRs, delete branches, or remove worktrees while acceptance is red.
+- Do not claim store deployment from a build, upload, or CI job. Verify the actual store state.
+- Do not call performance “instant” without measured, repeated evidence on the real app surface.
+- The physical-phone sideload is a development candidate, not an App Store release claim.
+
+## Current Git and PR state
+
+### Authoritative refs
+
+| Ref | SHA | State |
+|---|---|---|
+| `origin/main` | `7122dd6eba57e0c6eb923acd642db9396ade1334` | Live remote-main baseline |
+| local `main` worktree | `7122dd6eba57e0c6eb923acd642db9396ade1334` | Matches `origin/main` |
+| Tested mega application baseline | `716acabdeea6f6da9e97d5887601f50a488195be` | Pushed candidate installed on the phone and used for Apple acceptance |
+
+PR #295, **v2.0.1 mega convergence**, is open and draft: <https://github.com/0xSero/litter/pull/295>.
+
+- Merge state: `CLEAN`
+- Application diff at tested baseline `716acabd`: 33 files, +2,342 / -335 GitHub lines
+- Application commits at that baseline: 7 logical commits; this living goal is a separate documentation change
+- Mobile CI: shared-prep, Android, and iOS all green at `716acabd`
+- Release workflow: planning and Windows final-package test green; publishing jobs correctly skipped because this is not a release-triggering commit
+- Local mega worktree: no tracked source changes before this file; only the two pre-existing dirty submodules (`shared/third_party/codex` and `shared/third_party/ghostty`)
+
+The seven tested application commits are:
+
+1. `98981fa8` — conversation typography
+2. `d49db8b4` — Studio default appearance
+3. `12a7cbb1` — read-only Play status fallback
+4. `44b76b53` — render-isolation instrumentation and performance fixtures
+5. `57414ba6` — per-thread rebind isolation kernel on iOS and Android
+6. `7c4b07b4` — Android concurrency-test correction
+7. `716acabd` — cross-platform W1 production-path measurement fixtures and attribution
+
+### Other open PRs that still require disposition
+
+| PR | Branch | Purpose | Current action |
+|---|---|---|---|
+| #300 | `ci/ish-vdso-guard` | iSH VDSO failure/launch CI | Audit and capture or explicitly reject |
+| #298 | `fix/amp-current-modes` | Current Amp mode support | Audit and capture or explicitly reject |
+| #297 | `fix/ssh-host-key-change-confirmation` | Changed SSH host confirmation | Audit and capture or explicitly reject |
+| #260 | `codex/remove-alleycat-main-refresh` | Remove stale Alleycat refresh | Audit and capture or explicitly reject |
+| #254 | `codex/pi-chat-w00-m00-reconcile` | Chat pacing and queued follow-ups | Reconcile into the mega performance work |
+| #239 | `codex/local-studio-fidelity-performance` | Local Studio session fidelity/performance | Reconcile useful work into mega |
+
+No PR above may be closed merely to make the list look clean. Each needs a provenance/result record first.
+
+### Existing worktrees
+
+There are currently 14 registered worktrees, including the primary dirty checkout, the `main` worktree, the mega worktree, chat-performance/reconciliation worktrees, and release/testflight worktrees. Cleanup is intentionally deferred. Before removal, each worktree must be checked for:
+
+- tracked and untracked changes;
+- commits not reachable from the final mega/main history;
+- evidence or release artifacts not copied to their durable location;
+- a branch still backing an open PR.
+
+Use recoverable Git worktree removal only after those checks. Never recursively delete a broad directory.
+
+## Phone and store state
+
+### Physical iPhone — completed for the requested sideload
+
+Device: **Sero’s iPhone**, iPhone 15 Pro Max, CoreDevice ID `E64BFB56-4B4A-5BB7-B186-43F023D50EFA`.
+
+- Previous installed app: Litter `2.0.0` build `200000254`
+- Installed on 2026-08-14: Litter `2.0.1` build `200010001`
+- Bundle ID: `com.sigkitten.litter`
+- Source: exact mega commit `716acabdeea6f6da9e97d5887601f50a488195be`
+- Build: fresh Rust device library plus a fresh signed Debug/device relink; both build steps succeeded
+- Install: `devicectl` succeeded without uninstalling the app container
+- Launch: succeeded
+- Phone-side verification: installed-app query reports `2.0.1 / 200010001`
+- Uncompressed Debug `.app` size: 188 MiB. This is **not** the final release IPA/download/install-size measurement.
+
+This fulfills the immediate request to put the latest candidate on the phone. It does not make the candidate release-ready; Apple acceptance is still red below.
+
+### Apple distribution
+
+- Last verified App Store production state during this task: Litter `2.0.0`, build `200000260`, `READY_FOR_SALE`.
+- A fresh local App Store Connect query is currently blocked because the local `asc` CLI has no authentication configuration.
+- No v2.0.1 archive has been uploaded or submitted.
+- Required end state: accepted release build, TestFlight/device validation, App Store submission/release, and a fresh store query proving the live version/build.
+
+### Google Play
+
+- The release service account was previously proven unable to perform the required release operation because it lacks the needed Play Console release permission.
+- No v2.0.1 Play release has been uploaded or promoted.
+- Required user/admin boundary: grant the service account the correct app/release permission or complete the authenticated Play Console handoff.
+- Required end state: accepted AAB, target-track rollout completed, and a Play query/console check proving the deployed version code and status.
+
+## LOC target — currently red
+
+Frozen measurement command:
+
+```bash
+cloc --vcs=git --exclude-dir=third_party,GeneratedRust,Frameworks --csv --quiet
+```
+
+This counts tracked first-party code and excludes the two upstream submodules plus generated/package artifacts.
+
+| Tree | Code lines |
+|---|---:|
+| `origin/main` baseline `7122dd6` | 196,855 |
+| Mega candidate `716acabd` | 198,617 |
+| Current delta | **+1,762 (+0.90%)** |
+| Required 25%-reduced ceiling | **147,641** |
+| Reduction still required from mega | **50,976 lines** |
+
+The 25% requirement is not close to complete. GitHub's PR additions/deletions and `cloc` code lines are different metrics; acceptance uses the frozen `cloc` command above. Deletion is only valid when parity tests and product behavior remain intact.
+
+## Apple app acceptance — currently red
+
+Evidence directory:
+
+`/Users/sero/ai/projects/litter-release-evidence/v2.0.1/apple-app-full-716acabd/`
+
+Artifacts include the full log, a 289 MiB `.xcresult`, a continuous 24-minute/852 MiB simulator recording, SHA256 manifest, and `RESULTS.md`.
+
+### Full UI suite result
+
+- Target: actual `com.sigkitten.litter` app on iPhone 17 Pro simulator
+- Exact source: `716acabd`
+- Result: **18 tests, 13 passed, 5 failed**
+- XCTest verdict: `TEST EXECUTE FAILED`
+
+Failures and current classification:
+
+1. Expanded-mode code-block check: pre-W1 XCTest selector defect. The app renders the two-line code block as one accessibility element; the test incorrectly demands an exact standalone `UITEST_CODE_BLOCK` label.
+2. Back to Sessions at 300: real W1 fixture-seam defect plus a still-real navigation failure. The fixture seeds the Swift snapshot but lets `resumeThread` and `listThreads` call disconnected Rust transport. Failure-time hierarchy remains on Conversation after Back.
+3. Composer typing during foreign stream: unresolved product-vs-fixture behavior. Captured hierarchy has no focused element and no keyboard window; the composer never became first responder.
+4. Open conversation/back at 1,500 items: same fixture transport defect plus a real Back failure. Failure-time hierarchy remains on Conversation instead of Home.
+5. Session-search clearing: test expectation defect. The field did clear and restored the full list; XCUITest reports the empty field's placeholder value (`Search sessions`) instead of an empty string.
+
+Cross-cutting observed defect: production-fixture navigation sometimes waits about 60 seconds for the app-animation completion notification before XCTest can synthesize the tap.
+
+### Measured current behavior
+
+| Surface | Current measurement | Verdict |
+|---|---:|---|
+| Five open/Back cycles at 300 sessions | 75.161 s average batch, about 15 s/cycle | Unacceptable |
+| Conversation launch | 1.770 s average | Not instant |
+| 19-character composer probe | 0.619 s average | Measurable, but focus failed under foreign streaming |
+| 1,500-item scroll deceleration | 1.682 s average, 33.3% RSD | Too noisy for a regression claim |
+| Foreign-thread body isolation | Zero unrelated TimelineRow/SessionRow/Header/HomeCard evaluations | Structural isolation passes |
+
+The per-thread rebind kernel is implemented, but there is no valid claim that it has made the user-visible operations fast yet.
+
+### Apple diagnosis/review status
+
+- GLM-5.3 source diagnosis: complete at `/private/tmp/glm53-apple-ui-failures-diagnosis.md`.
+- GLM-5.3 runtime evidence extraction from the existing `.xcresult` and video: in progress; no new app run or source edit.
+- Fable-5 final failure adjudication: held until the runtime evidence is sealed. Interim direction is `AMEND`, not an automatic W1 rollback, but no final artifact exists yet.
+- No corrective source patch has been authorized or implemented after this red run.
+
+## Android acceptance
+
+- W1 Android instrumentation and deterministic tests are present at `716acabd`.
+- Mobile CI successfully generated bindings, built JNI/Android, assembled the app, and passed Android unit tests.
+- No current full Android emulator/physical-device feature recording has been accepted for the final v2.0.1 candidate.
+- No final Android performance baseline, release AAB size report, or Play deployment exists yet.
+
+Android is CI-green but not release-complete.
+
+## Consultant and reviewer ledger
+
+Completed inputs include:
+
+- GLM-5.3 implementation/diagnosis lanes for iOS and Android W1.
+- Kimi-K3 instant-performance audit: `/Users/sero/ai/projects/litter-release-evidence/v2.0.1/perf-0b/kimi-k3-instant-performance-audit.md`.
+- DeepSeek-V4-Pro instant-session audit: `/Users/sero/ai/projects/litter-release-evidence/v2.0.1/perf-0b/deepseek-instant-session-perf-audit.md`.
+- Fable-5 W1 diff review: `/Users/sero/.claude/plans/fresh-fable-5-w1-floating-diffie.md` (`PASS` for that exact W1 diff before the later full-suite failures were discovered).
+- Fable-5 residual performance plan and protocol amendments under `/Users/sero/.claude/plans/`.
+
+Still required:
+
+- final Fable-5 adjudication of the real Apple UI failures;
+- GLM-5.3 implementation of only the authorized corrective workpack;
+- independent regression review after each performance/LOC slice;
+- final Claude Code Opus-5 review of the complete release diff and evidence;
+- explicit aggregation showing which Kimi/DeepSeek/Fable recommendations were accepted, rejected, or superseded.
+
+## Remaining work, in order
+
+### Gate 0 — preserve the current phone candidate and evidence
+
+- [x] Build `716acabd` for the physical iPhone.
+- [x] Install and launch `2.0.1 (200010001)`.
+- [x] Verify the version from the phone.
+- [ ] Have the user confirm the app opens and retained expected account/server state.
+
+### Gate 1 — finish Apple failure adjudication
+
+- [ ] Seal GLM's existing-runtime evidence report.
+- [ ] Have Fable read the report and issue the exact amend/revert ruling.
+- [ ] Record a minimal file allowlist, tests, commit subject, and rollback condition.
+
+### Gate 2 — repair the Apple test/fixture failures
+
+- [ ] Fix the two invalid XCTest expectations without weakening behavior checks.
+- [ ] Prevent fixture-mode Home/Sessions actions from using disconnected production transport.
+- [ ] Determine why Back remains on Conversation.
+- [ ] Determine why the composer cannot acquire focus during foreign-thread streaming.
+- [ ] Attribute and eliminate the 60-second animation/quiescence stall.
+- [ ] Commit each logical correction separately.
+- [ ] Run the focused failures, then all iOS unit tests, then the full 18-test UI suite with a new continuous recording.
+
+### Gate 3 — deliver the actual performance fix
+
+- [ ] Profile real session loading, Home/Sessions derivation, navigation path mutation, conversation hydration, composer focus, and streaming update propagation.
+- [ ] Move shared reconciliation/derivation work into Rust where both platforms need it.
+- [ ] Virtualize or page large lists and avoid whole-corpus hydration where evidence identifies it as the cost.
+- [ ] Ensure foreign-thread updates do not invalidate the displayed conversation or composer.
+- [ ] Ensure rapid follow-ups queue/send deterministically without flicker, lost input, duplicate sends, or whole-screen invalidation.
+- [ ] Re-run at 300 sessions, 1,500 items, and a larger real-world corpus.
+- [ ] Require repeated p50/p95 measurements and recordings on both platforms.
+
+### Gate 4 — Codex-like composer acceptance
+
+- [ ] Compare against the provided Codex composer reference.
+- [ ] Preserve attachment, project/folder, web, model, voice, and send controls.
+- [ ] Keep the text surface stable while models/streaming/session state updates.
+- [ ] Verify keyboard focus, dictation, long model names, rapid follow-ups, and accessibility.
+- [ ] Capture simulator and physical-device screenshots/video.
+
+### Gate 5 — full feature parity matrix
+
+Test on iOS and Android, using real connected services where required:
+
+- launch, onboarding, theme, settings, and persistence;
+- Kittylitter, Local Studio, connected-computer, direct URL, SSH, pairing, and reconnect;
+- Home, projects/folders, sessions, search, pagination, resume, new thread, rename/archive/delete;
+- message rendering, reasoning/system sections, Markdown/code/diff/tool calls/images;
+- streaming, multi-turn, follow-ups, steer, stop, retry, approvals, and user input requests;
+- composer attachments, model/reasoning controls, web, voice/dictation, and keyboard behavior;
+- notifications, backgrounding, Live Activities/watch surfaces where applicable;
+- terminal/shell and saved-app flows;
+- offline/error/reconnect and state restoration;
+- accessibility, rotation, light/dark themes, memory pressure, and long-list stress.
+
+Every row needs a pass/fail result, platform/build identity, and evidence link. “CI green” is not a substitute for device behavior.
+
+### Gate 6 — size and performance report
+
+- [ ] Produce signed Release IPA and AAB artifacts.
+- [ ] Record archive, compressed download, and installed sizes separately.
+- [ ] Attribute the largest binaries/resources/dependencies.
+- [ ] Compare v2.0.1 with the live 2.0.0 builds.
+- [ ] Record cold/warm launch, session load, conversation open, Back, typing, scroll, multi-follow-up, CPU, memory, hangs, and dropped frames.
+- [ ] Keep raw traces, commands, manifests, and recordings.
+
+### Gate 7 — 25% LOC reduction without lost functionality
+
+- [ ] Inventory duplicate Swift/Kotlin logic that belongs in shared Rust.
+- [ ] Audit generated, copied, obsolete, dead, and superseded modules.
+- [ ] Prefer deletion/consolidation over new abstraction layers.
+- [ ] Land deletion slices with focused parity tests and size/build evidence.
+- [ ] Reach at most 147,641 tracked first-party code lines under the frozen command.
+- [ ] Re-run the complete feature/performance matrix after the final deletion.
+
+### Gate 8 — single mega PR and final review
+
+- [ ] Reconcile all open PRs and branches into an explicit keep/drop ledger.
+- [ ] Ensure all kept work appears in PR #295 as logical commits.
+- [ ] Update PR purpose, changes, tests, measurements, screenshots, and known limitations.
+- [ ] Obtain GLM-5.3 review, Fable-5 plan/diff review, and Claude Code Opus-5 final review.
+- [ ] Resolve every blocking review item.
+- [ ] Require all CI and device gates green at the final SHA.
+
+### Gate 9 — merge and synchronize main
+
+- [ ] Merge the accepted mega PR.
+- [ ] Fetch `origin`.
+- [ ] Fast-forward local `main` to `origin/main`.
+- [ ] Prove local `main` and `origin/main` have the same SHA.
+- [ ] Build/test once more from the clean final `main` checkout.
+
+### Gate 10 — deploy both stores
+
+- [ ] Assign final v2.0.1 marketing/build/version codes in source.
+- [ ] Upload and validate TestFlight; test the distributed build on the physical iPhone.
+- [ ] Submit/release v2.0.1 to the Apple App Store and verify the resulting store state.
+- [ ] Resolve Play service-account authorization with the user/admin.
+- [ ] Upload the signed AAB, promote to the requested Play track, and verify rollout state.
+- [ ] Confirm the store artifacts correspond to the final `origin/main` SHA.
+
+### Gate 11 — cleanup only after deployment proof
+
+- [ ] Close superseded PRs with links to the capturing mega commits.
+- [ ] Delete merged/dead remote branches.
+- [ ] Delete safe local branches.
+- [ ] Remove obsolete worktrees after dirty/unpushed audits.
+- [ ] Preserve deliberate submodule dirt and evidence archives.
+- [ ] Finish on local `main`, clean except explicitly documented state, exactly matching `origin/main`.
+
+## Definition of done
+
+The v2.0.1 goal is complete only when all statements below are true:
+
+- The same final SHA is on local `main`, `origin/main`, and both store release provenance records.
+- Apple and Android unit/integration/UI suites are green.
+- Physical iPhone and Android-device acceptance is green with recordings.
+- Long-list navigation, session loading, conversation open/Back, composer typing, and multi-turn follow-ups meet the accepted performance thresholds without flicker.
+- No required feature was removed or silently degraded.
+- First-party tracked code is at least 25% below the frozen `origin/main` baseline.
+- The signed release sizes and performance report are complete.
+- Fable-5, GLM-5.3, and Claude Code Opus-5 blocking reviews are resolved.
+- Apple App Store and Google Play both show the v2.0.1 release successfully deployed.
+- Obsolete PRs, branches, and worktrees are removed only after provenance-safe capture.
+
+Until then, status is **ACTIVE — NOT RELEASE READY**.

--- a/tools/scripts/list-play-tracks.py
+++ b/tools/scripts/list-play-tracks.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python3
 """Read-only Google Play track / versionCode listing.
 
-Reads the current track state for a package by creating an ephemeral
-(uncommitted draft) edit, fetching its track list, and deleting the edit.
-Deletion is performed in a ``finally`` block so it runs on every normal and
-error path. This tool performs no published-state changes of any kind: it
-never publishes bundles, promotes artifacts, updates track entries, or
-commits an edit.
+Primary path keeps the ephemeral (uncommitted draft) edit: create an edit,
+fetch its track list, and delete the edit in a ``finally`` block so the edit is
+removed on every normal and error path. This tool performs no published-state
+changes of any kind: it never publishes bundles, promotes artifacts, updates
+track entries, or commits an edit.
+
+Fallback path: when ``Edits.insert`` is rejected with ``403 PERMISSION_DENIED``
+(the service account lacks edit permission but may still hold read access),
+the tool switches to the read-only ``applications.tracks.releases.list``
+method, probing the standard track names (``production``, ``beta``, ``qa``,
+``alpha``, and the legacy ``internal`` alias). That direct method excludes
+obsolete releases and returns at most 20 releases per track, and it provides no
+``userFraction``/staged-rollout fraction, so a ``PUBLISHED`` lifecycle state is
+reported as available-on-track only, never as terminal rollout proof.
 
 Output is a single normalized JSON document.
 """
@@ -30,6 +38,23 @@ from typing import Any
 DEFAULT_PACKAGE = "com.sigkitten.litter.android"
 PLAY_PUBLISHER_SCOPE = "https://www.googleapis.com/auth/androidpublisher"
 PLAY_EDITS_BASE = "https://androidpublisher.googleapis.com/androidpublisher/v3/applications"
+DIRECT_TRACK_PROBES = ("production", "beta", "qa", "alpha", "internal")
+DIRECT_GET_NOTE = (
+    "Read-only fallback via applications.tracks.releases.list: excludes obsolete "
+    "releases, returns at most 20 releases per track, and exposes no "
+    "userFraction/staged-rollout fraction; PUBLISHED means available on the track, "
+    "not terminal rollout proof."
+)
+
+
+class PlayApiHttpError(RuntimeError):
+    """HTTP error from the Play API, carrying the status code, URL, and body."""
+
+    def __init__(self, code: int, url: str, body: str) -> None:
+        self.code = code
+        self.url = url
+        self.body = body
+        super().__init__(f"HTTP {code} for {url}: {body}")
 
 
 def b64url(data: bytes) -> str:
@@ -107,17 +132,126 @@ def api_request_json(
             return json.loads(response.read().decode() or "{}")
     except urllib.error.HTTPError as exc:
         body = exc.read().decode()
-        raise RuntimeError(f"HTTP {exc.code} for {url}: {body}") from exc
+        raise PlayApiHttpError(exc.code, url, body) from exc
+
+
+def _to_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def is_permission_denied(exc: PlayApiHttpError) -> bool:
+    """True when an edits.insert call was rejected for permission (403)."""
+    return exc.code == 403 and "PERMISSION_DENIED" in (exc.body or "")
+
+
+def map_lifecycle_state(raw_state: str | None) -> str | None:
+    """Map a raw releaseLifecycleState to the legacy track status vocabulary.
+
+    Only two exact mappings are defined (DRAFT -> draft, PUBLISHED -> completed).
+    Every other state (IN_REVIEW, NOT_APPROVED, APPROVED_NOT_PUBLISHED, ...)
+    maps to ``None``; its raw value is preserved verbatim instead and the
+    userFraction is unknown (null).
+    """
+    if raw_state == "DRAFT":
+        return "draft"
+    if raw_state == "PUBLISHED":
+        return "completed"
+    return None
+
+
+def _edit_release_to_common(release: dict[str, Any]) -> dict[str, Any]:
+    codes = [
+        c for c in (_to_int(v) for v in (release.get("versionCodes") or [])) if c is not None
+    ]
+    return {
+        "name": release.get("name"),
+        "versionCodes": codes,
+        "status": release.get("status"),
+        "userFraction": release.get("userFraction"),
+        "releaseLifecycleState": None,
+    }
+
+
+def _direct_release_to_common(release: dict[str, Any]) -> dict[str, Any]:
+    codes: list[int] = []
+    for artifact in release.get("activeArtifacts") or []:
+        code = _to_int(artifact.get("versionCode"))
+        if code is not None:
+            codes.append(code)
+    raw_state = release.get("releaseLifecycleState")
+    return {
+        "name": release.get("releaseName"),
+        "versionCodes": codes,
+        "status": map_lifecycle_state(raw_state),
+        "userFraction": None,
+        "releaseLifecycleState": raw_state,
+    }
+
+
+def list_tracks_direct(package: str, token: str, base_url: str = PLAY_EDITS_BASE) -> dict[str, Any]:
+    """Read-only fallback: probe standard tracks via applications.tracks.releases.list.
+
+    Per-track 404 (track does not exist) is recorded separately from a 200 with
+    no releases (track exists but is empty). The canonical track name is taken
+    from the first release's ``track`` field, falling back to the probed name.
+    """
+    probes = list(DIRECT_TRACK_PROBES)
+    resolved: list[str] = []
+    not_found: list[str] = []
+    empty: list[str] = []
+    tracks: list[dict[str, Any]] = []
+    for track in probes:
+        url = f"{base_url}/{package}/tracks/{urllib.parse.quote(track, safe='')}/releases"
+        try:
+            payload = api_request_json(url, token, method="GET")
+        except PlayApiHttpError as exc:
+            if exc.code == 404:
+                not_found.append(track)
+                continue
+            raise
+        releases = payload.get("releases") or []
+        if not releases:
+            empty.append(track)
+            continue
+        resolved_name = releases[0].get("track") or track
+        resolved.append(resolved_name)
+        tracks.append(
+            {
+                "track": resolved_name,
+                "releases": [_direct_release_to_common(r) for r in releases],
+            }
+        )
+    return {
+        "source": "direct-get",
+        "tracks": tracks,
+        "directGet": {
+            "probed": probes,
+            "resolved": resolved,
+            "notFound": not_found,
+            "empty": empty,
+            "note": DIRECT_GET_NOTE,
+        },
+    }
 
 
 def list_tracks(package: str, token: str, base_url: str = PLAY_EDITS_BASE) -> dict[str, Any]:
     """Create an ephemeral edit, read tracks, and delete the edit.
 
-    The DELETE is issued inside ``finally`` so it is attempted on every exit
-    path (normal return and any exception, including KeyboardInterrupt).
+    Falls back to the read-only ``applications.tracks.releases.list`` path only
+    when ``edits.insert`` returns 403 PERMISSION_DENIED. The DELETE is issued
+    inside ``finally`` so it is attempted on every exit path (normal return and
+    any exception, including KeyboardInterrupt).
     """
     edits_url = f"{base_url}/{package}/edits"
-    edit = api_request_json(edits_url, token, method="POST", payload={})
+    try:
+        edit = api_request_json(edits_url, token, method="POST", payload={})
+    except PlayApiHttpError as exc:
+        if is_permission_denied(exc):
+            return list_tracks_direct(package, token, base_url)
+        raise
     edit_id = edit.get("id")
     if not edit_id:
         raise RuntimeError("create-edit preflight returned no edit id")
@@ -139,31 +273,37 @@ def list_tracks(package: str, token: str, base_url: str = PLAY_EDITS_BASE) -> di
             delete_failure = exc
     if delete_failure is not None:
         raise RuntimeError(f"failed to delete ephemeral edit {edit_id}: {delete_failure}") from delete_failure
-    return tracks_payload
+
+    tracks: list[dict[str, Any]] = []
+    for track in tracks_payload.get("tracks") or []:
+        name = track.get("track")
+        if not name:
+            continue
+        tracks.append(
+            {
+                "track": name,
+                "releases": [_edit_release_to_common(r) for r in (track.get("releases") or [])],
+            }
+        )
+    return {"source": "edit", "tracks": tracks, "directGet": None}
 
 
-def _to_int(value: Any) -> int | None:
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def normalize(package: str, tracks_payload: dict[str, Any], generated_at: str) -> dict[str, Any]:
-    tracks = tracks_payload.get("tracks") or []
+def normalize(package: str, result: dict[str, Any], generated_at: str) -> dict[str, Any]:
+    source = result.get("source")
+    tracks = result.get("tracks") or []
     by_track: dict[str, Any] = {}
     overall_highest: int | None = None
+    resolved_tracks: list[str] = []
     for track in tracks:
         name = track.get("track")
         if not name:
             continue
+        resolved_tracks.append(name)
         releases: list[dict[str, Any]] = []
         track_highest: int | None = None
         for release in track.get("releases") or []:
             codes = [
-                c
-                for c in (_to_int(v) for v in (release.get("versionCodes") or []))
-                if c is not None
+                c for c in (release.get("versionCodes") or []) if c is not None
             ]
             for c in codes:
                 if overall_highest is None or c > overall_highest:
@@ -176,29 +316,36 @@ def normalize(package: str, tracks_payload: dict[str, Any], generated_at: str) -
                     "versionCodes": codes,
                     "status": release.get("status"),
                     "userFraction": release.get("userFraction"),
+                    "releaseLifecycleState": release.get("releaseLifecycleState"),
                 }
             )
         by_track[name] = {
             "releases": releases,
             "highestVersionCode": track_highest,
+            "source": source,
         }
-    return {
+    normalized: dict[str, Any] = {
         "packageName": package,
         "generatedAtUtc": generated_at,
         "readOnly": True,
+        "source": source,
+        "resolvedTracks": resolved_tracks,
         "highestVersionCode": overall_highest,
         "tracks": by_track,
     }
+    if result.get("directGet") is not None:
+        normalized["directGet"] = result["directGet"]
+    return normalized
 
 
 def _self_test() -> int:
-    """In-process mock of the Play API proving create -> GET tracks -> DELETE
-    ordering and that DELETE still fires when the tracks GET fails."""
+    """Deterministic in-process mock covering edit path, 403 fallback,
+    non-403 no-fallback, per-track 404 vs empty, raw-state preservation,
+    status mapping, source marker, and null userFraction."""
     import http.server
     import threading
 
     calls: list[tuple[str, str]] = []
-    state: dict[str, Any] = {"fail_get": False}
 
     class Handler(http.server.BaseHTTPRequestHandler):
         def log_message(self, *args: Any) -> None:  # silence
@@ -212,79 +359,142 @@ def _self_test() -> int:
             self.end_headers()
             self.wfile.write(body)
 
+        def _handle(self, method: str) -> None:
+            calls.append((method, self.path))
+            status, obj = self.server.routes.get(
+                (method, self.path), (404, {"error": {"message": "unrouted"}})
+            )
+            self._send(status, obj)
+
         def do_POST(self) -> None:
-            calls.append(("POST", self.path))
-            if self.path.endswith("/edits"):
-                self._send(200, {"id": "edit-1", "expiryTimeSeconds": "3600"})
-            else:
-                self._send(404, {})
+            self._handle("POST")
 
         def do_GET(self) -> None:
-            calls.append(("GET", self.path))
-            if self.path.endswith("/edits/edit-1/tracks"):
-                if state["fail_get"]:
-                    self._send(500, {"error": {"message": "forced"}})
-                else:
-                    self._send(200, {
-                        "kind": "androidpublisher#tracksListResponse",
-                        "tracks": [
-                            {
-                                "track": "internal",
-                                "releases": [
-                                    {"name": "1", "versionCodes": ["200000253"], "status": "completed"},
-                                ],
-                            },
-                            {
-                                "track": "production",
-                                "releases": [
-                                    {"name": "1", "versionCodes": ["200000250", "200000249"], "status": "completed"},
-                                ],
-                            },
-                        ],
-                    })
-            else:
-                self._send(404, {})
+            self._handle("GET")
 
         def do_DELETE(self) -> None:
-            calls.append(("DELETE", self.path))
-            if self.path.endswith("/edits/edit-1"):
-                self._send(200, {})
-            else:
-                self._send(404, {})
+            self._handle("DELETE")
 
-    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    base = f"http://127.0.0.1:{server.server_address[1]}/applications"
-    try:
-        # Happy path.
-        payload = list_tracks("com.example", "fake-token", base_url=base)
-        assert calls[-3:] == [
-            ("POST", "/applications/com.example/edits"),
-            ("GET", "/applications/com.example/edits/edit-1/tracks"),
-            ("DELETE", "/applications/com.example/edits/edit-1"),
-        ], f"unexpected call order: {calls[-3:]}"
-        normalized = normalize("com.example", payload, "test")
-        assert normalized["highestVersionCode"] == 200000253, normalized
-        assert normalized["tracks"]["production"]["highestVersionCode"] == 200000250, normalized
-
-        # Error path: GET tracks returns 500; DELETE must still fire in finally.
+    def run(routes: dict[tuple[str, str], tuple[int, Any]], fn: Any) -> Any:
+        server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        server.routes = routes  # type: ignore[attr-defined]
         calls.clear()
-        state["fail_get"] = True
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        base = f"http://127.0.0.1:{server.server_address[1]}/applications"
         try:
-            list_tracks("com.example", "fake-token", base_url=base)
-        except RuntimeError:
-            pass
-        else:
-            raise AssertionError("expected list_tracks to raise on GET 500")
-        assert ("POST", "/applications/com.example/edits") in calls, calls
-        assert ("DELETE", "/applications/com.example/edits/edit-1") in calls, f"DELETE missing on error path: {calls}"
+            return fn(base)
+        finally:
+            server.shutdown()
+            server.server_close()
 
-        print("self-test: OK (create -> GET tracks -> DELETE; DELETE fires on error path)")
-        return 0
-    finally:
-        server.shutdown()
-        server.server_close()
+    # Scenario 1: happy edit path (no fallback).
+    edit_routes = {
+        ("POST", "/applications/com.example/edits"): (200, {"id": "edit-1", "expiryTimeSeconds": "3600"}),
+        ("GET", "/applications/com.example/edits/edit-1/tracks"): (200, {
+            "kind": "androidpublisher#tracksListResponse",
+            "tracks": [
+                {"track": "internal", "releases": [
+                    {"name": "1", "versionCodes": ["200000253"], "status": "completed", "userFraction": 1.0},
+                ]},
+                {"track": "production", "releases": [
+                    {"name": "1", "versionCodes": ["200000250", "200000249"], "status": "completed"},
+                ]},
+            ],
+        }),
+        ("DELETE", "/applications/com.example/edits/edit-1"): (200, {}),
+    }
+    result = run(edit_routes, lambda b: list_tracks("com.example", "fake-token", base_url=b))
+    assert result["source"] == "edit", result
+    assert calls == [
+        ("POST", "/applications/com.example/edits"),
+        ("GET", "/applications/com.example/edits/edit-1/tracks"),
+        ("DELETE", "/applications/com.example/edits/edit-1"),
+    ], calls
+    normalized = normalize("com.example", result, "test")
+    assert normalized["source"] == "edit", normalized
+    assert normalized["resolvedTracks"] == ["internal", "production"], normalized
+    assert normalized["highestVersionCode"] == 200000253, normalized
+    assert normalized["tracks"]["production"]["highestVersionCode"] == 200000250, normalized
+    assert normalized["tracks"]["production"]["source"] == "edit", normalized
+    assert normalized["tracks"]["internal"]["releases"][0]["status"] == "completed", normalized
+    assert normalized["tracks"]["internal"]["releases"][0]["userFraction"] == 1.0, normalized
+    assert normalized["tracks"]["internal"]["releases"][0]["releaseLifecycleState"] is None, normalized
+    assert "directGet" not in normalized, normalized
+
+    # Scenario 2: 403 PERMISSION_DENIED on edits.insert -> direct fallback.
+    direct_routes = {
+        ("POST", "/applications/com.example/edits"): (403, {
+            "error": {"code": 403, "message": "The caller does not have permission", "status": "PERMISSION_DENIED"},
+        }),
+        ("GET", "/applications/com.example/tracks/production/releases"): (200, {"releases": [
+            {"track": "production", "releaseName": "1", "releaseLifecycleState": "PUBLISHED",
+             "activeArtifacts": [{"versionCode": 200000250}]},
+            {"track": "production", "releaseName": "2", "releaseLifecycleState": "DRAFT",
+             "activeArtifacts": [{"versionCode": 200000253}]},
+        ]}),
+        ("GET", "/applications/com.example/tracks/beta/releases"): (200, {"releases": [
+            {"track": "beta", "releaseName": "3", "releaseLifecycleState": "IN_REVIEW",
+             "activeArtifacts": [{"versionCode": 200000240}]},
+        ]}),
+        ("GET", "/applications/com.example/tracks/qa/releases"): (404, {"error": {"message": "not found"}}),
+        ("GET", "/applications/com.example/tracks/alpha/releases"): (200, {"releases": []}),
+        ("GET", "/applications/com.example/tracks/internal/releases"): (404, {"error": {"message": "not found"}}),
+    }
+    result = run(direct_routes, lambda b: list_tracks("com.example", "fake-token", base_url=b))
+    assert result["source"] == "direct-get", result
+    assert ("DELETE", "/applications/com.example/edits/edit-1") not in calls, calls
+    assert result["directGet"]["probed"] == ["production", "beta", "qa", "alpha", "internal"], result
+    assert result["directGet"]["resolved"] == ["production", "beta"], result
+    assert result["directGet"]["notFound"] == ["qa", "internal"], result
+    assert result["directGet"]["empty"] == ["alpha"], result
+    normalized = normalize("com.example", result, "test")
+    assert normalized["source"] == "direct-get", normalized
+    assert normalized["resolvedTracks"] == ["production", "beta"], normalized
+    assert normalized["highestVersionCode"] == 200000253, normalized
+    prod = normalized["tracks"]["production"]
+    assert prod["source"] == "direct-get", normalized
+    assert [r["releaseLifecycleState"] for r in prod["releases"]] == ["PUBLISHED", "DRAFT"], normalized
+    assert [r["status"] for r in prod["releases"]] == ["completed", "draft"], normalized
+    assert all(r["userFraction"] is None for r in prod["releases"]), normalized
+    beta = normalized["tracks"]["beta"]
+    assert beta["releases"][0]["releaseLifecycleState"] == "IN_REVIEW", normalized
+    assert beta["releases"][0]["status"] is None, normalized
+    assert beta["releases"][0]["userFraction"] is None, normalized
+    assert normalized["directGet"]["notFound"] == ["qa", "internal"], normalized
+    assert normalized["directGet"]["empty"] == ["alpha"], normalized
+
+    # Scenario 3: non-403 edits.insert error must NOT fall back.
+    non403_routes = {
+        ("POST", "/applications/com.example/edits"): (500, {"error": {"message": "boom"}}),
+    }
+    raised = False
+    try:
+        run(non403_routes, lambda b: list_tracks("com.example", "fake-token", base_url=b))
+    except PlayApiHttpError as exc:
+        raised = True
+        assert exc.code == 500, exc
+    assert raised, "expected non-403 edits.insert failure to propagate"
+    assert calls == [("POST", "/applications/com.example/edits")], calls
+
+    # Scenario 4: edit path tracks GET 500 -> DELETE still fires in finally.
+    fail_get_routes = {
+        ("POST", "/applications/com.example/edits"): (200, {"id": "edit-1"}),
+        ("GET", "/applications/com.example/edits/edit-1/tracks"): (500, {"error": {"message": "forced"}}),
+        ("DELETE", "/applications/com.example/edits/edit-1"): (200, {}),
+    }
+    raised = False
+    try:
+        run(fail_get_routes, lambda b: list_tracks("com.example", "fake-token", base_url=b))
+    except PlayApiHttpError as exc:
+        raised = True
+        assert exc.code == 500, exc
+    assert raised, "expected tracks GET 500 to propagate"
+    assert ("DELETE", "/applications/com.example/edits/edit-1") in calls, calls
+
+    print("self-test: OK (edit path, 403 direct fallback, non-403 no-fallback, "
+          "404 vs empty, raw-state, mapping, source, null fraction, resolved names)")
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -310,14 +520,14 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit(f"error: service account JSON not found: {service_account_path}")
 
     token = issue_token(service_account_path)
-    tracks_payload = list_tracks(args.package, token)
+    result = list_tracks(args.package, token)
     generated_at = (
         dt.datetime.now(tz=dt.timezone.utc)
         .replace(microsecond=0)
         .isoformat()
         .replace("+00:00", "Z")
     )
-    normalized = normalize(args.package, tracks_payload, generated_at)
+    normalized = normalize(args.package, result, generated_at)
     text = json.dumps(normalized, indent=2 if args.pretty else None, sort_keys=True)
     if args.output:
         out_path = pathlib.Path(args.output)


### PR DESCRIPTION
## Sole remaining delivery PR — v2.0.1 mega convergence (IN PROGRESS)

This draft is the **single convergence PR** for the v2.0.1 delivery chain. It captures the already-green `#293` (C1) and `#294` (C2) content onto the exact base `7122dd6e`. It is a **draft** and under active Fable batch review. No perf, simplification, or release-identity work is claimed to be present in this PR yet.

**Base:** `7122dd6eba57e0c6eb923acd642db9396ade1334` (`origin/main` tip at capture time)
**Head:** `codex/v201-mega` @ `12a7cbb1b10045801a22218811d66e4765287c08`
**merge-base(`codex/v201-mega`, `7122dd6e`)** = `7122dd6e` (linear, 3 commits, no extras)
**Diff:** 10 files, +406 / −125

### C1/C2 commit → source → patch-id table

| # | Mega commit | Source commit | Subject | Patch ID (`--stable`) |
|---|---|---|---|---|
| C1a | `98981fa8c7ab7bcda5b3a899f10d394294e22049` | `b18cd9c2` (in `#293`; standalone origin `#276`) | chat: refine conversation typography [skip mobile-release] | `6b05176b70425697b3d30315ed8a241acf6bdb45` |
| C1b | `d49db8b47e564107ed050bcfb6a28914cb728581` | `92a66e95` (in `#293`; standalone origin `#277`) | appearance: make Studio the default theme [skip mobile-release] | `6c63280c98b72a9a14bd6a38980af4c5d7629184` |
| C2 | `12a7cbb1b10045801a22218811d66e4765287c08` | `f675fb24` (`#294`) | release: add read-only Play status fallback [skip mobile-release] | `95785c21c9cb502d3f8bed97397d27920b084c9d` |

Subjects preserved verbatim (including `[skip mobile-release]`), in original order.

### Content-equivalence proof (10/10 blob match)

Every file at `codex/v201-mega` matches its source head byte-for-byte:

- 9 C1 files == `92a66e95` (PR `#293` head)
- `tools/scripts/list-play-tracks.py` == `f675fb24` (PR `#294` head)

`git diff --check` clean (full range, per-commit, and single-file).

### Evidence

- **Base CI:** run `31753697269` — terminal success at `7122dd6e` (Android build/tests + iOS build/LitterTests green).
- **Source PRs `#293`/`#294`:** already green (targeted `xcodebuild -only-testing` 13/13; `python3 -m py_compile` + `python3 tools/scripts/list-play-tracks.py --self-test` OK).

### Related PRs being converged

- `#293` — ui: simplify typography and semantic theme defaults (C1 batch)
- `#294` — release: add read-only Play status fallback (C2)
- `#276` — chat: refine conversation typography (standalone origin of C1a)
- `#277` — appearance: make Studio the default theme (standalone origin of C1b)

### Mega plan

The v2.0.1 delivery is consolidated into this **single PR** on top of `7122dd6e`. Downstream **PERF-0a/PERF-0b, PERF-1, composer, adjudicated simplification, testing, release identity, and deployment preparation** will be added as **later logical commits to this same mega PR** (the user requires one mega PR — no separate chain/PR).

### Open LOC (lines-of-code) user-choice gate — NOT included in this PR

Fable final union certified only **P10 −875 / P50 −1,990 / P90 −3,185** versus the required **−49,237**; the stop-condition is **open**. The user must choose:

- **A** — revise the target to the certified bands, or
- **B** — proceed while recording the 25% target as unmet, or
- **C** — explicitly name live product surfaces to delete and accept functionality loss (not recommended).

Reference: `FABLE_LOC_UNION_ADJUDICATION_READY`.

---

FABLE_MEGA_C1_C2_BATCH_REVIEW_READY
