### PR TITLE
feat(ios): paginate older turns with infinite scroll

### DIFF
--- a/apps/ios/Litter.xcodeproj/project.pbxproj
+++ b/apps/ios/Litter.xcodeproj/project.pbxproj
@@ -1966,12 +1966,12 @@
 			projectRoot = "";
 			targets = (
 				A3D84F588EDBC1EA550D6691 /* Litter */,
-				4D58398238C075D3A3A3AB9B /* LitterLiveActivity */,
 				6EBBC661C017816B2D4245DF /* LitterMac */,
-				DA07A1EAC6173D09F6FB99D9 /* LitterTests */,
-				7BB0106D190F10717D781234 /* LitterUITests */,
+				4D58398238C075D3A3A3AB9B /* LitterLiveActivity */,
 				3B991C03E72B1546CAD35698 /* LitterWatch */,
 				C0C98C6012493B73CDD5AD6E /* LitterWatchComplications */,
+				DA07A1EAC6173D09F6FB99D9 /* LitterTests */,
+				7BB0106D190F10717D781234 /* LitterUITests */,
 			);
 		};
 /* End PBXProject section */

--- a/apps/ios/Sources/Litter/Models/AppModel.swift
+++ b/apps/ios/Sources/Litter/Models/AppModel.swift
@@ -1995,14 +1995,14 @@ final class AppModel {
         return nil
     }
 
-    private static let initialTurnPageSize: UInt32 = 5
-    private static let olderTurnPageSize: UInt32 = 5
+    private static let initialTurnPageSize: UInt32 = 20
+    private static let olderTurnPageSize: UInt32 = 20
 
     /// Fetch the first page of turns for a thread whose `initialTurnsLoaded`
     /// is still false. Called after a resume that sent `exclude_turns: true`
     /// against a v0.125+ server.
     func loadInitialTurns(threadId key: ThreadKey) async {
-        await loadTurnPage(key: key, cursor: nil, limit: Self.initialTurnPageSize)
+        _ = await loadTurnPage(key: key, cursor: nil, limit: Self.initialTurnPageSize)
     }
 
     func loadInitialTurnsIfNeeded(threadId key: ThreadKey) async {
@@ -2013,18 +2013,18 @@ final class AppModel {
     }
 
     /// Fetch the next older page of turns using the thread's current cursor.
-    /// No-op when no cursor is available (older-turns button should be hidden
-    /// in that case).
-    func loadOlderTurns(threadId key: ThreadKey) async {
+    /// No-op when the loaded history cache has reached the start of the
+    /// server-side session and no cursor remains.
+    func loadOlderTurns(threadId key: ThreadKey) async -> Bool {
         guard let cursor = threadSnapshot(for: key)?.olderTurnsCursor,
               !cursor.isEmpty else {
-            return
+            return false
         }
-        await loadTurnPage(key: key, cursor: cursor, limit: Self.olderTurnPageSize)
+        return await loadTurnPage(key: key, cursor: cursor, limit: Self.olderTurnPageSize)
     }
 
-    private func loadTurnPage(key: ThreadKey, cursor: String?, limit: UInt32) async {
-        if loadingTurnPageThreadKeys.contains(key) { return }
+    private func loadTurnPage(key: ThreadKey, cursor: String?, limit: UInt32) async -> Bool {
+        if loadingTurnPageThreadKeys.contains(key) { return false }
         loadingTurnPageThreadKeys.insert(key)
         defer { loadingTurnPageThreadKeys.remove(key) }
 
@@ -2034,8 +2034,10 @@ final class AppModel {
                 cursor: cursor,
                 limit: limit
             )
+            return true
         } catch {
             lastError = error.localizedDescription
+            return false
         }
     }
 

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -128,7 +128,7 @@ struct ConversationView: View {
             onForkFromUserItem: forkFromMessage,
             onOpenConversation: onOpenConversation,
             onLoadOlderTurns: { key in
-                Task { await appModel.loadOlderTurns(threadId: key) }
+                await appModel.loadOlderTurns(threadId: key)
             }
         )
         .overlay(alignment: .bottomLeading) {
@@ -604,7 +604,7 @@ private struct ConversationMessageList: View {
     let onEditUserItem: (ConversationItem) -> Void
     let onForkFromUserItem: (ConversationItem) -> Void
     var onOpenConversation: ((ThreadKey) -> Void)? = nil
-    let onLoadOlderTurns: (ThreadKey) -> Void
+    let onLoadOlderTurns: (ThreadKey) async -> Bool
     @State private var isNearBottom = true
     @State private var autoFollowStreaming = true
     @State private var userIsDraggingScroll = false
@@ -623,6 +623,12 @@ private struct ConversationMessageList: View {
     @State private var initialBottomScrollThreadScopeID: String?
     @State private var programmaticBottomScrollSettling = false
     @State private var programmaticBottomScrollGeneration = 0
+    @State private var scrollPosition = ScrollPosition(idType: String.self)
+    @State private var nativeScrollView: UIScrollView?
+    @State private var visibleTurnIDs: [String] = []
+    @State private var requestedOlderTurnsCursor: String?
+    @State private var requestedOlderTurnsThreadKey: ThreadKey?
+    @State private var showOlderPageLoader = false
     @AppStorage("collapseTurns") private var collapseTurns = false
     private static let latestButtonShowDistance: CGFloat = 48
     private static let nearBottomRestoreDistance: CGFloat = 12
@@ -630,8 +636,18 @@ private struct ConversationMessageList: View {
     private static let bottomAnchorID = "conversation-message-list-bottom"
     private static let scrollCoordinateSpaceName = "conversation-message-list-scroll"
 
+    private var shouldCollapseTurns: Bool {
+        ConversationTurnCollapsePolicy.shouldCollapse(
+            preferenceEnabled: collapseTurns,
+            itemCount: items.count
+        )
+    }
+
     private var expandedRecentTurnCount: Int {
-        return collapseTurns ? 1 : .max
+        ConversationTurnCollapsePolicy.expandedRecentTurnCount(
+            preferenceEnabled: collapseTurns,
+            itemCount: items.count
+        )
     }
 
     private var sourceTurns: [TranscriptTurn] {
@@ -698,22 +714,6 @@ private struct ConversationMessageList: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
                         LazyVStack(alignment: .leading, spacing: 10) {
-                            if !initialTurnsLoaded && hasOlderTurns && !turns.isEmpty {
-                                ConversationLoadingIndicator(label: "Loading earlier messages...")
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.vertical, 12)
-                            } else if hasOlderTurns {
-                                Button {
-                                    onLoadOlderTurns(activeThreadKey)
-                                } label: {
-                                    Text("Load earlier messages")
-                                        .litterFont(.caption, weight: .semibold)
-                                        .foregroundColor(LitterTheme.accent)
-                                        .frame(maxWidth: .infinity)
-                                        .padding(.vertical, 8)
-                                }
-                                .buttonStyle(.plain)
-                            }
                             ForEach(turns) { turn in
                                 let isLastTurn = turn.id == lastTurnID
                                 ConversationTurnRow(
@@ -748,7 +748,12 @@ private struct ConversationMessageList: View {
                                 .equatable()
                                 .turnDebugOverlay(turnId: turn.id)
                             }
+
+                            Color.clear
+                                .frame(height: 1)
+                                .id(Self.bottomAnchorID)
                         }
+                        .scrollTargetLayout()
                         .frame(maxWidth: LitterPlatform.isRegularSurface(horizontalSizeClass: horizontalSizeClass) ? 760 : .infinity)
                         .frame(maxWidth: .infinity, alignment: .center)
                         .padding(.horizontal, 16)
@@ -765,16 +770,24 @@ private struct ConversationMessageList: View {
                                 .padding(.top, 40)
                         }
 
-                        Color.clear
-                            .frame(height: 1)
-                            .id(Self.bottomAnchorID)
-                            .padding(.horizontal, 16)
                     }
                     .frame(maxWidth: .infinity, minHeight: viewport.size.height, alignment: .top)
+                    .background(
+                        ConversationScrollViewResolver(scrollView: $nativeScrollView)
+                            .allowsHitTesting(false)
+                    )
                 }
                 .id(activeThreadScopeID)
                 .scrollIndicators(.hidden)
                 .scrollDismissesKeyboard(.interactively)
+                // Keep one semantic scroll position for both user tracking and
+                // programmatic edge jumps. Unlike ScrollViewProxy, an edge
+                // command can replace active deceleration immediately.
+                .scrollPosition($scrollPosition, anchor: .bottom)
+                .onScrollTargetVisibilityChange(idType: String.self, threshold: 0.01) { turnIDs in
+                    visibleTurnIDs = turnIDs
+                    prefetchOlderTurnsIfNeeded(visibleTurnIDs: turnIDs, turns: turns)
+                }
                 .coordinateSpace(name: Self.scrollCoordinateSpaceName)
                 .onScrollGeometryChange(for: CGFloat.self) { geometry in
                     max(0, geometry.contentSize.height - geometry.visibleRect.maxY)
@@ -813,6 +826,11 @@ private struct ConversationMessageList: View {
                     distanceFromBottom = 0
                     initialBottomScrollThreadScopeID = nil
                     waitingForDataExpired = false
+                    scrollPosition = ScrollPosition(idType: String.self)
+                    visibleTurnIDs = []
+                    requestedOlderTurnsCursor = nil
+                    requestedOlderTurnsThreadKey = nil
+                    showOlderPageLoader = false
                     syncTranscriptTurns(resetExpansion: true)
                     StreamingRendererCoordinator.shared.reset()
                     requestInitialBottomScrollIfNeeded(proxy)
@@ -824,6 +842,18 @@ private struct ConversationMessageList: View {
                 .onChange(of: items) { _, _ in
                     syncTranscriptTurns()
                     requestInitialBottomScrollIfNeeded(proxy)
+                }
+                .onChange(of: olderTurnsCursor) { oldCursor, newCursor in
+                    guard oldCursor != newCursor else { return }
+                    requestedOlderTurnsCursor = nil
+                    requestedOlderTurnsThreadKey = nil
+                    showOlderPageLoader = false
+                    DispatchQueue.main.async {
+                        prefetchOlderTurnsIfNeeded(
+                            visibleTurnIDs: visibleTurnIDs,
+                            turns: mergedRenderableTurns
+                        )
+                    }
                 }
                 .onChange(of: collapseTurns) {
                     syncTranscriptTurns(resetExpansion: true)
@@ -878,6 +908,16 @@ private struct ConversationMessageList: View {
                     .padding(.trailing, 14)
                     .padding(.bottom, 10)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+
+                if showOlderPageLoader, hasOlderTurns {
+                    ConversationLoadingIndicator(label: "Loading earlier messages...")
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(.ultraThinMaterial, in: Capsule())
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                        .padding(.top, topInset + 8)
+                        .allowsHitTesting(false)
                 }
             }
             }
@@ -947,16 +987,94 @@ private struct ConversationMessageList: View {
         }
     }
 
-    private func scrollToBottom(_ proxy: ScrollViewProxy) {
+    private func scrollToBottom(_: ScrollViewProxy) {
         isNearBottom = true
         distanceFromBottom = 0
         programmaticBottomScrollGeneration &+= 1
         let generation = programmaticBottomScrollGeneration
         programmaticBottomScrollSettling = true
-        proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
+        stopMomentumAndJumpToNativeBottom()
+        scrollPosition.scrollTo(edge: .bottom)
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.bottomScrollSettleDuration) {
             guard programmaticBottomScrollGeneration == generation else { return }
             programmaticBottomScrollSettling = false
+        }
+    }
+
+    private func stopMomentumAndJumpToNativeBottom() {
+        guard let nativeScrollView else { return }
+
+        // End an in-progress pan as well as inertial deceleration. Without
+        // this, SwiftUI can accept a semantic scroll command and then have the
+        // still-running UIKit scroll animation write a newer offset over it.
+        let panGesture = nativeScrollView.panGestureRecognizer
+        if panGesture.state != .possible {
+            panGesture.isEnabled = false
+            panGesture.isEnabled = true
+        }
+        nativeScrollView.setContentOffset(nativeScrollView.contentOffset, animated: false)
+
+        let inset = nativeScrollView.adjustedContentInset
+        let topOffset = -inset.top
+        let bottomOffset = max(
+            topOffset,
+            nativeScrollView.contentSize.height - nativeScrollView.bounds.height + inset.bottom
+        )
+        nativeScrollView.setContentOffset(
+            CGPoint(x: nativeScrollView.contentOffset.x, y: bottomOffset),
+            animated: false
+        )
+    }
+
+    private func prefetchOlderTurnsIfNeeded(
+        visibleTurnIDs: [String],
+        turns: [TranscriptTurn]
+    ) {
+        guard let earliestVisibleIndex = ConversationInfiniteScrollPolicy.earliestVisibleIndex(
+            visibleIDs: visibleTurnIDs,
+            orderedIDs: turns.map(\.id)
+        ), earliestVisibleIndex <= ConversationInfiniteScrollPolicy.olderPrefetchDistance else { return }
+
+        requestOlderTurnsPage(showLoaderIfCacheExhausted: earliestVisibleIndex == 0)
+    }
+
+    private func requestOlderTurnsPage(showLoaderIfCacheExhausted: Bool) {
+        guard initialTurnsLoaded,
+              let cursor = olderTurnsCursor,
+              !cursor.isEmpty else { return }
+        let requestKey = activeThreadKey
+
+        if requestedOlderTurnsCursor == cursor,
+           requestedOlderTurnsThreadKey == requestKey {
+            if showLoaderIfCacheExhausted {
+                scheduleOlderPageLoader(for: cursor, threadKey: requestKey)
+            }
+            return
+        }
+
+        requestedOlderTurnsCursor = cursor
+        requestedOlderTurnsThreadKey = requestKey
+        if showLoaderIfCacheExhausted {
+            scheduleOlderPageLoader(for: cursor, threadKey: requestKey)
+        }
+
+        Task {
+            let didLoad = await onLoadOlderTurns(requestKey)
+            guard !didLoad,
+                  requestedOlderTurnsCursor == cursor,
+                  requestedOlderTurnsThreadKey == requestKey else { return }
+            requestedOlderTurnsCursor = nil
+            requestedOlderTurnsThreadKey = nil
+            showOlderPageLoader = false
+        }
+    }
+
+    private func scheduleOlderPageLoader(for cursor: String, threadKey: ThreadKey) {
+        Task {
+            try? await Task.sleep(for: .milliseconds(250))
+            guard requestedOlderTurnsCursor == cursor,
+                  requestedOlderTurnsThreadKey == threadKey else { return }
+            showOlderPageLoader = true
         }
     }
 
@@ -1063,7 +1181,7 @@ private struct ConversationMessageList: View {
         to nextTurns: [TranscriptTurn],
         resetExpansion: Bool
     ) -> Bool {
-        guard collapseTurns,
+        guard shouldCollapseTurns,
               !resetExpansion,
               !currentTurns.isEmpty,
               nextTurns.count == currentTurns.count + 1,
@@ -1364,26 +1482,76 @@ private struct CollapsedTurnMetaItem: View {
     }
 }
 
+private struct ConversationScrollViewResolver: UIViewRepresentable {
+    @Binding var scrollView: UIScrollView?
+
+    func makeUIView(context: Context) -> ResolverView {
+        let view = ResolverView()
+        view.onResolve = updateResolvedScrollView
+        return view
+    }
+
+    func updateUIView(_ uiView: ResolverView, context: Context) {
+        uiView.onResolve = updateResolvedScrollView
+        uiView.resolveWhenAttached()
+    }
+
+    private func updateResolvedScrollView(_ resolved: UIScrollView?) {
+        guard scrollView !== resolved else { return }
+        scrollView = resolved
+    }
+
+    final class ResolverView: UIView {
+        var onResolve: ((UIScrollView?) -> Void)?
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            resolveWhenAttached()
+        }
+
+        func resolveWhenAttached() {
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                var ancestor = superview
+                while let view = ancestor {
+                    if let scrollView = view as? UIScrollView {
+                        onResolve?(scrollView)
+                        return
+                    }
+                    ancestor = view.superview
+                }
+                onResolve?(nil)
+            }
+        }
+    }
+}
+
 private struct ScrollToBottomIndicator: View {
     let action: () -> Void
     @State private var bob = false
 
     var body: some View {
-        Button(action: action) {
-            HStack(spacing: 8) {
-                Image(systemName: "arrow.down")
-                    .litterFont(.caption, weight: .bold)
-                    .offset(y: bob ? 1.5 : -1.5)
-                    .animation(.easeInOut(duration: 0.75).repeatForever(autoreverses: true), value: bob)
-                Text("Latest")
-                    .litterFont(.caption, weight: .semibold)
-            }
-            .foregroundColor(LitterTheme.textPrimary)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .modifier(GlassCapsuleModifier())
+        HStack(spacing: 8) {
+            Image(systemName: "arrow.down")
+                .litterFont(.caption, weight: .bold)
+                .offset(y: bob ? 1.5 : -1.5)
+                .animation(.easeInOut(duration: 0.75).repeatForever(autoreverses: true), value: bob)
+            Text("Latest")
+                .litterFont(.caption, weight: .semibold)
         }
+        .foregroundColor(LitterTheme.textPrimary)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .modifier(GlassCapsuleModifier())
         .contentShape(Capsule())
+        // A normal Button tap can be consumed merely to stop an actively
+        // decelerating ScrollView. Give this overlay first refusal so Latest
+        // executes on that same tap, even while momentum is still active.
+        .highPriorityGesture(TapGesture().onEnded(action))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Latest")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction { action() }
         .onAppear {
             bob = true
         }

--- a/apps/ios/Sources/Litter/Views/SettingsView.swift
+++ b/apps/ios/Sources/Litter/Views/SettingsView.swift
@@ -133,7 +133,7 @@ struct SettingsView: View {
                         Text("Collapse Turns")
                             .litterFont(.subheadline)
                             .foregroundColor(LitterTheme.textPrimary)
-                        Text("Collapse previous turns into cards")
+                        Text("Collapse previous turns into cards; large conversations collapse automatically")
                             .litterFont(.caption)
                             .foregroundColor(LitterTheme.textSecondary)
                     }

--- a/apps/ios/Sources/Litter/Views/TranscriptTurn.swift
+++ b/apps/ios/Sources/Litter/Views/TranscriptTurn.swift
@@ -1,5 +1,40 @@
 import Foundation
 
+enum ConversationTurnCollapsePolicy {
+    /// Rendering every message/tool view in a large restored page can exhaust
+    /// SwiftUI's layout budget and leave the conversation surface blank.
+    static let automaticItemThreshold = 200
+
+    static func shouldCollapse(
+        preferenceEnabled: Bool,
+        itemCount: Int
+    ) -> Bool {
+        preferenceEnabled || itemCount >= automaticItemThreshold
+    }
+
+    static func expandedRecentTurnCount(
+        preferenceEnabled: Bool,
+        itemCount: Int
+    ) -> Int {
+        shouldCollapse(preferenceEnabled: preferenceEnabled, itemCount: itemCount) ? 1 : .max
+    }
+}
+
+enum ConversationInfiniteScrollPolicy {
+    static let olderPrefetchDistance = 6
+
+    static func earliestVisibleIndex(
+        visibleIDs: [String],
+        orderedIDs: [String]
+    ) -> Int? {
+        guard !visibleIDs.isEmpty else { return nil }
+        let indicesByID = Dictionary(
+            uniqueKeysWithValues: orderedIDs.enumerated().map { ($1, $0) }
+        )
+        return visibleIDs.compactMap { indicesByID[$0] }.min()
+    }
+}
+
 struct TranscriptTurn: Identifiable, Equatable {
     private static let collapsedExcerptLimit = 180
 
@@ -185,11 +220,14 @@ struct TranscriptTurn: Identifiable, Equatable {
     }
 
     private static func mergedExplorationTurn(from turns: [TranscriptTurn]) -> TranscriptTurn? {
-        guard let first = turns.first else { return nil }
+        guard let last = turns.last else { return nil }
         let items = turns.flatMap(\.items)
         let isLive = turns.contains(where: \.isLive)
         return TranscriptTurn(
-            id: "exploration-turn-\(first.id)",
+            // Anchor the merged row to its newest constituent turn. Older
+            // pages prepend to this run, so its identity remains stable and
+            // SwiftUI can preserve the visible scroll position.
+            id: "exploration-turn-\(last.id)",
             items: items,
             preview: makePreview(from: items),
             isLive: isLive,

--- a/apps/ios/Tests/LitterTests/PerformanceHelpersTests.swift
+++ b/apps/ios/Tests/LitterTests/PerformanceHelpersTests.swift
@@ -3,6 +3,51 @@ import XCTest
 
 @MainActor
 final class PerformanceHelpersTests: XCTestCase {
+    func testLargeConversationAutomaticallyCollapsesOlderTurns() {
+        let threshold = ConversationTurnCollapsePolicy.automaticItemThreshold
+
+        XCTAssertEqual(
+            ConversationTurnCollapsePolicy.expandedRecentTurnCount(
+                preferenceEnabled: false,
+                itemCount: threshold - 1
+            ),
+            .max
+        )
+        XCTAssertEqual(
+            ConversationTurnCollapsePolicy.expandedRecentTurnCount(
+                preferenceEnabled: false,
+                itemCount: threshold
+            ),
+            1
+        )
+        XCTAssertEqual(
+            ConversationTurnCollapsePolicy.expandedRecentTurnCount(
+                preferenceEnabled: true,
+                itemCount: 1
+            ),
+            1
+        )
+    }
+
+    func testInfiniteScrollPrefetchesBeforeTheVisibleCacheEdge() {
+        let orderedIDs = (0..<20).map { "turn-\($0)" }
+
+        XCTAssertEqual(
+            ConversationInfiniteScrollPolicy.earliestVisibleIndex(
+                visibleIDs: ["turn-8", "turn-9", "turn-10"],
+                orderedIDs: orderedIDs
+            ),
+            8
+        )
+        XCTAssertEqual(
+            ConversationInfiniteScrollPolicy.earliestVisibleIndex(
+                visibleIDs: ["turn-4", "turn-5", "turn-6"],
+                orderedIDs: orderedIDs
+            ),
+            4
+        )
+    }
+
     func testTranscriptTurnBuilderCollapsesPreviousTurnOnceANewLiveTurnStarts() {
         let baseTime = Date(timeIntervalSince1970: 100)
         let turns = TranscriptTurn.build(
@@ -195,6 +240,59 @@ final class PerformanceHelpersTests: XCTestCase {
         XCTAssertEqual(merged[0].items.count, 1)
         XCTAssertEqual(merged[1].items.count, 1)
         XCTAssertEqual(merged[2].items.count, 1)
+    }
+
+    func testExplorationMergeKeepsItsIdentityWhenOlderTurnsArePrepended() {
+        let baseTime = Date(timeIntervalSince1970: 500)
+        let olderTurn = TranscriptTurn.build(
+            from: [makeExplorationItem(
+                command: "pwd",
+                actionKind: .read,
+                path: "/tmp",
+                turnId: "turn-0",
+                turnIndex: 0,
+                timestamp: baseTime
+            )],
+            threadStatus: .ready,
+            expandedRecentTurnCount: 1
+        )[0]
+        let firstLoadedTurn = TranscriptTurn.build(
+            from: [makeExplorationItem(
+                command: "cat reducer.rs",
+                actionKind: .read,
+                path: "/tmp/reducer.rs",
+                turnId: "turn-1",
+                turnIndex: 1,
+                timestamp: baseTime.addingTimeInterval(1)
+            )],
+            threadStatus: .ready,
+            expandedRecentTurnCount: 1
+        )[0]
+        let newestTurn = TranscriptTurn.build(
+            from: [makeExplorationItem(
+                command: "rg pendingSteers",
+                actionKind: .search,
+                path: "/tmp/reducer.rs",
+                query: "pendingSteers",
+                turnId: "turn-2",
+                turnIndex: 2,
+                timestamp: baseTime.addingTimeInterval(2)
+            )],
+            threadStatus: .ready,
+            expandedRecentTurnCount: 1
+        )[0]
+
+        let beforePrepend = TranscriptTurn.mergeConsecutiveExplorationTurnsForRendering([
+            firstLoadedTurn,
+            newestTurn,
+        ])
+        let afterPrepend = TranscriptTurn.mergeConsecutiveExplorationTurnsForRendering([
+            olderTurn,
+            firstLoadedTurn,
+            newestTurn,
+        ])
+
+        XCTAssertEqual(beforePrepend.first?.id, afterPrepend.first?.id)
     }
 
     func testMessageRenderCacheReusesStableAssistantRevisionKey() {


### PR DESCRIPTION
Closes part of #306
Depends on #307 (land after it so the paged cursor behaves predictably).

## Problem
iOS conversation history loading was manual (a "Load earlier messages" button), page size 5, and the "Latest" jump button could be consumed just by stopping a decelerating ScrollView.

## Changes (ConversationView, AppModel, TranscriptTurn, Settings, tests)
- Scroll-triggered prefetch: tracks visible turn IDs and loads the next older page as the user approaches the top, debounced per cursor so concurrent prefetches collapse.
- Page size 5 → 20; `loadOlderTurns` now returns whether a page loaded.
- "Latest" re-routed through semantic `ScrollPosition` + a UIKit scroll-view resolver so the jump executes even while momentum is decelerating.
- Merged exploration rows anchored to their newest constituent turn so prepending older pages keeps scroll identity stable.
- Auto-collapse conversations past 200 items.

## Scope
iOS only; the conversation surface is shared across all runtimes, so this improves every provider (codex, claude, pi, local-studio, opencode).

## Parity note
Android still uses a manual "Load earlier messages" button (ConversationScreen.kt). The Rust metadata-read fix (#307) benefits both; the infinite-scroll UX is iOS-only in this change. Android parity is a follow-up.

## Tests
- 3 new PerformanceHelpersTests: auto-collapse, prefetch-before-cache-edge, exploration identity.

## Verification
- `make ios-sim-fast`
