### PR TITLE
fix(android): session rows only open when tapping the leftmost status dot

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/ui/common/FormattedText.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/common/FormattedText.kt
@@ -131,6 +131,21 @@ private fun LinkifiedText(
     val annotated = remember(text, linkColor) {
         linkifiedAnnotatedString(text, linkColor)
     }
+    val hasLinks = WebLinkRegex.containsMatchIn(text)
+    // Only attach link tap handling when the text actually contains links.
+    // ClickableText consumes taps across the whole span to detect link hits,
+    // which would otherwise swallow the parent row's click when a session
+    // title has no links at all.
+    if (!hasLinks) {
+        Text(
+            text = annotated,
+            style = TextStyle(color = color, fontSize = fontSize),
+            maxLines = maxLines,
+            overflow = TextOverflow.Ellipsis,
+            modifier = modifier,
+        )
+        return
+    }
     ClickableText(
         text = annotated,
         style = TextStyle(color = color, fontSize = fontSize),


### PR DESCRIPTION
Closes #309

## Problem
On Android, session rows on the Home dashboard only open a conversation when tapping the **leftmost status-dot region**. Tapping the title, meta line, or right half of a row does nothing.

## Root cause
Session titles render through `FormattedText` → `LinkifiedText`, which uses Compose `ClickableText` to open web links. `ClickableText` consumes taps across the **entire text span** to detect link hits, so the parent row's `combinedClickable` never receives the tap on any part of the title. Only the leftmost status-dot column (outside the title) reached the row's click handler.

## Change
`apps/android/.../common/FormattedText.kt`:
- Only attach `ClickableText` link handling when the title actually contains a URL (`WebLinkRegex.containsMatchIn(text)`).
- Titles without links render as a plain `Text`, so taps pass through to the row's `combinedClickable`.
- Titles that do contain links keep the existing link-opening behavior unchanged.

## Verification
- Android emulator: tapping the right half (x=900) and middle (x=500) of a session row now opens the conversation; the leftmost dot still works.
- Android-only change (`FormattedText.kt`); no iOS impact.

## Tests
Manual emulator verification (the click behavior is Compose gesture/rendering, covered by the manual repro).
