### PR TITLE
fix(ios): make conversation back button work again

### DIFF
--- a/apps/ios/Sources/Litter/LitterApp.swift
+++ b/apps/ios/Sources/Litter/LitterApp.swift
@@ -1987,11 +1987,12 @@ private struct ConversationDestinationScreen: View {
         .overlay(alignment: .top) {
             GlassMorphContainer(spacing: 8) {
                 HStack(spacing: 8) {
-                    Button { onBack() } label: {
+                    Button(action: onBack) {
                         Image(systemName: "chevron.left")
                             .font(LitterFont.styled(size: 17, weight: .semibold))
                             .foregroundColor(LitterTheme.textPrimary)
                             .frame(width: 40, height: 40)
+                            .contentShape(Circle())
                     }
                     .buttonStyle(.plain)
                     .modifier(GlassCircleModifier())

--- a/apps/ios/Sources/Litter/LitterApp.swift
+++ b/apps/ios/Sources/Litter/LitterApp.swift
@@ -773,6 +773,7 @@ private struct HomeNavigationView: View {
                     ConversationDestinationScreen(
                         threadKey: threadKey,
                         bottomInset: bottomInset,
+                        onBack: { popCurrentRoute() },
                         onResumeSessions: { showSessions(for: $0) },
                         onOpenConversation: { replaceTopConversation(with: $0) },
                         onInfo: { navigationPath.append(.conversationInfo(threadKey)) }
@@ -1881,13 +1882,13 @@ private struct HomeNavigationView: View {
 }
 
 private struct ConversationDestinationScreen: View {
-    @Environment(\.dismiss) private var dismiss
     @Environment(AppModel.self) private var appModel
     @Environment(AppState.self) private var appState
     @AppStorage("workDir") private var workDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.path ?? "/"
     @State private var screenModel = ConversationScreenModel()
     let threadKey: ThreadKey
     let bottomInset: CGFloat
+    let onBack: () -> Void
     let onResumeSessions: (String) -> Void
     let onOpenConversation: (ThreadKey) -> Void
     var onInfo: (() -> Void)?
@@ -1986,7 +1987,7 @@ private struct ConversationDestinationScreen: View {
         .overlay(alignment: .top) {
             GlassMorphContainer(spacing: 8) {
                 HStack(spacing: 8) {
-                    Button { dismiss() } label: {
+                    Button { onBack() } label: {
                         Image(systemName: "chevron.left")
                             .font(LitterFont.styled(size: 17, weight: .semibold))
                             .foregroundColor(LitterTheme.textPrimary)


### PR DESCRIPTION
Fixes #313

The conversation back button introduced in cf82de5f ("ui: move conversation controls into composer") does nothing because it calls `dismiss()` on a path-driven `NavigationStack` (a no-op for programmatically-pushed routes), and its hit area is only the thin chevron glyph.

Changes:
- Back the custom glass-overlay back button with `popCurrentRoute()`, which pops the path-driven navigation stack — matching how every other pop in this codebase works and how the Android side of cf82de5f pops its nav stack.
- Add `.contentShape(Circle())` so the entire 40x40 glass circle is tappable, matching SavedAppDetailView.

Verification:
- Built with `make ios` (signed package lane), installed on iPhone 17 Pro simulator.
- Open a session → tap back → returns to dashboard every time.

Before cf82de5f the conversation used the native nav-bar back button (shipped in 2.0); this restores equivalent behavior while keeping the custom glass top-bar design.