### PR TITLE
fix(ios): clear stale dashboard blur after navigation

### DIFF
--- a/apps/ios/Sources/Litter/Views/HomeSessionsScrollView.swift
+++ b/apps/ios/Sources/Litter/Views/HomeSessionsScrollView.swift
@@ -1542,16 +1542,18 @@ final class HomeRowContainer: UIView {
     func forceResetPinchBlurIfIdle() {
         if LitterPlatform.rendersAsMacApp { return }
         if UIAccessibility.isReduceTransparencyEnabled { return }
-        // A live fade-out is still scrubbing the animator's
-        // fractionComplete back to 0 — don't yank the animator out
-        // from under it.
-        if fadeLink != nil { return }
         // If the scroll host says a pinch is active, the animator is
         // being scrubbed in real time. Leave it alone.
         if scrollHost?.pinchActive == true { return }
+        // Navigation can leave the fade display link alive even though
+        // no pinch is active. Treat that as stale transition state and
+        // cancel it before removing the stale effect view. The pinch
+        // path lazily reinstalls the view and animator when needed.
+        fadeLink?.invalidate()
+        fadeLink = nil
         tearDownPinchBlurAnimator()
+        pinchBlur.removeFromSuperview()
         pinchBlur.effect = nil
-        pinchBlurAnimator = makePinchBlurAnimator()
     }
 
     /// Smoothly wind the blur back to zero on pinch release. Uses


### PR DESCRIPTION
Fixes #314

After popping back from a conversation, dashboard session rows can render as opaque gray bars: the row's `pinchBlur` `UIVisualEffectView` is stuck at full effect because NavigationStack push/pop finishes the paused `UIViewPropertyAnimator` that drives it. The stale view persists until an external gesture forces a re-layout.

Changes:
- In `forceResetPinchBlurIfIdle`, cancel any stale fade `CADisplayLink` and remove the `UIVisualEffectView` from the row hierarchy instead of rebuilding the paused animator. The pinch path lazily reinstalls the view and animator when a real pinch begins.

Verification:
- Built with `make ios` (signed package lane), installed on iPhone 17 Pro simulator.
- Dashboard → open session → back: rows render with titles immediately, no gray bars.