### PR TITLE
perf(ios): theme switching now perceptually instant (2+s -> instant, matching Android)

### DIFF
--- a/apps/ios/Sources/Litter/LitterApp.swift
+++ b/apps/ios/Sources/Litter/LitterApp.swift
@@ -452,9 +452,7 @@ struct ContentView: View {
         .onChange(of: colorScheme) { _, nextColorScheme in
             // iOS toggles `colorScheme` while capturing light+dark
             // app-switcher snapshots on background. Reacting to that
-            // bumps `themeManager.themeVersion`, which the navigation
-            // root uses as `.id(...)` and would tear down every
-            // in-flight @State (composer text, focus, scroll) every
+            // recolors views through the @Observable ThemeStore every
             // time the user switches apps. Only react when the scene
             // is actually active — i.e., a real user theme toggle.
             guard scenePhase == .active else { return }
@@ -513,7 +511,6 @@ struct ContentView: View {
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .ignoresSafeArea(.container, edges: [.top, .bottom])
-        .id(themeManager.themeVersion)
         .onAppear {
             Task { await conversationWarmup.prewarmIfNeeded() }
         }

--- a/apps/ios/Sources/Litter/Models/ThemeManager.swift
+++ b/apps/ios/Sources/Litter/Models/ThemeManager.swift
@@ -7,13 +7,16 @@ extension Notification.Name {
 }
 
 /// Thread-safe store for resolved themes, accessible from any isolation context.
-/// ThemeManager writes here; LitterTheme reads from here.
-final class ThemeStore: Sendable {
+/// ThemeManager writes here; LitterTheme reads from here. Marked @Observable so
+/// SwiftUI tracks every LitterTheme color read and recolors theme-consuming
+/// views when the theme changes, without tearing down the navigation tree.
+@Observable
+final class ThemeStore: @unchecked Sendable {
     static let shared = ThemeStore()
 
-    nonisolated(unsafe) var light: ResolvedTheme = .defaultLight
-    nonisolated(unsafe) var dark: ResolvedTheme = .defaultDark
-    nonisolated(unsafe) var colorScheme: ColorScheme = .dark
+    var light: ResolvedTheme = .defaultLight
+    var dark: ResolvedTheme = .defaultDark
+    var colorScheme: ColorScheme = .dark
 }
 
 enum LitterAppearanceMode: String, CaseIterable, Identifiable {
@@ -72,7 +75,6 @@ final class ThemeManager {
     private(set) var lightTheme: ResolvedTheme = .defaultLight
     private(set) var darkTheme: ResolvedTheme = .defaultDark
     private(set) var appearanceMode: LitterAppearanceMode = .system
-    private(set) var themeVersion: Int = 0
     private(set) var themeIndex: [ThemeIndexEntry] = []
     private var systemColorScheme: ColorScheme = .dark
 
@@ -119,7 +121,6 @@ final class ThemeManager {
         appearanceMode = mode
         UserDefaults.standard.set(mode.rawValue, forKey: Self.appearanceModeKey)
         syncStore()
-        themeVersion += 1
         writeToSharedDefaults()
         notifyHighlighter()
     }
@@ -129,7 +130,6 @@ final class ThemeManager {
         systemColorScheme = colorScheme
         guard appearanceMode == .system else { return }
         syncStore()
-        themeVersion += 1
         notifyHighlighter()
     }
 
@@ -137,7 +137,6 @@ final class ThemeManager {
         selectedLightSlug = slug
         lightTheme = loadAndResolve(slug) ?? .defaultLight
         syncStore()
-        themeVersion += 1
         writeToSharedDefaults()
         notifyHighlighter()
     }
@@ -146,7 +145,6 @@ final class ThemeManager {
         selectedDarkSlug = slug
         darkTheme = loadAndResolve(slug) ?? .defaultDark
         syncStore()
-        themeVersion += 1
         writeToSharedDefaults()
         notifyHighlighter()
     }

--- a/apps/ios/Sources/Litter/Views/AppearanceSettingsView.swift
+++ b/apps/ios/Sources/Litter/Views/AppearanceSettingsView.swift
@@ -138,7 +138,6 @@ struct AppearanceSettingsView: View {
             }
             .padding(.vertical, 6)
             .environment(\.textScale, ConversationTextSize.clamped(rawValue: textSizeStep).scale)
-            .id(themeManager.themeVersion)
             .listRowBackground(LitterTheme.backgroundGradient)
             .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12))
         } header: {

--- a/apps/ios/Sources/Litter/Views/CodeBlockView.swift
+++ b/apps/ios/Sources/Litter/Views/CodeBlockView.swift
@@ -10,7 +10,6 @@ struct CodeBlockView: View {
             if isDiffLanguage(language) {
                 SyntaxHighlightedDiffText(
                     diff: code,
-                    titleHint: language.isEmpty ? nil : language,
                     fontSize: LitterFont.conversationDiffPointSize
                 )
                 .padding(12)

--- a/apps/ios/Sources/Litter/Views/ConversationTimelineView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationTimelineView.swift
@@ -370,7 +370,6 @@ extension AnyTransition {
 
 private struct ConversationTimelineItemRow: View, Equatable {
     private let renderCache = MessageRenderCache.shared
-    @Environment(ThemeManager.self) private var themeManager
 
     let item: ConversationItem
     let serverId: String
@@ -592,7 +591,6 @@ private struct ConversationTimelineItemRow: View, Equatable {
             text: data.text,
             isStreaming: isStreamingMessage,
             label: assistantLabel,
-            themeVersion: themeManager.themeVersion,
             onSnapshotRendered: isStreamingMessage ? onStreamingSnapshotRendered : nil
         )
     }
@@ -2188,7 +2186,6 @@ private struct ConversationDiffDetailSheet: View {
     let title: String
     let stats: DiffStats
     let sections: [PresentedDiffSectionModel]
-    @Environment(ThemeManager.self) private var themeManager
     @Environment(\.dismiss) private var dismiss
     @State private var collapsedSectionIDs: Set<String> = []
     private let fullDiffFontSize = LitterFont.conversationDiffPointSize
@@ -2263,7 +2260,6 @@ private struct ConversationDiffDetailSheet: View {
             }
         }
         .presentationDetents([.medium, .large])
-        .id(themeManager.themeVersion)
     }
 
     private var usesStickyHeaders: Bool {
@@ -2280,7 +2276,6 @@ private struct ConversationDiffDetailSheet: View {
                 ScrollView(.horizontal, showsIndicators: true) {
                     SyntaxHighlightedDiffText(
                         diff: section.diff,
-                        titleHint: section.title.isEmpty ? nil : section.title,
                         fontSize: fullDiffFontSize
                     )
                         .padding(.horizontal, 8)

--- a/apps/ios/Sources/Litter/Views/DiffRendering.swift
+++ b/apps/ios/Sources/Litter/Views/DiffRendering.swift
@@ -11,7 +11,6 @@ func isDiffLanguage(_ language: String?) -> Bool {
 
 struct SyntaxHighlightedDiffText: View {
     let diff: String
-    var titleHint: String? = nil
     var fontSize: CGFloat = 12
 
     @Environment(\.colorScheme) private var colorScheme
@@ -20,9 +19,9 @@ struct SyntaxHighlightedDiffText: View {
 
     private struct RenderInputs: Equatable {
         let diff: String
-        let titleHint: String?
         let fontSize: CGFloat
         let colorScheme: ColorScheme
+        let themeSlug: String
     }
 
     var body: some View {
@@ -30,19 +29,18 @@ struct SyntaxHighlightedDiffText: View {
         .task(id: renderInputs) {
             renderedDiff = syntaxHighlightedDiffAttributedString(
                 diff: diff,
-                titleHint: titleHint,
-                fontSize: fontSize * textScale,
-                colorScheme: colorScheme
+                fontSize: fontSize * textScale
             )
         }
     }
 
     private var renderInputs: RenderInputs {
-        RenderInputs(
+        let resolved = colorScheme == .dark ? ThemeStore.shared.dark : ThemeStore.shared.light
+        return RenderInputs(
             diff: diff,
-            titleHint: titleHint,
             fontSize: fontSize * textScale,
-            colorScheme: colorScheme
+            colorScheme: colorScheme,
+            themeSlug: resolved.slug
         )
     }
 }
@@ -84,9 +82,7 @@ private struct DiffAttributedTextView: UIViewRepresentable {
 
 private func syntaxHighlightedDiffAttributedString(
     diff: String,
-    titleHint: String?,
-    fontSize: CGFloat,
-    colorScheme: ColorScheme
+    fontSize: CGFloat
 ) -> NSAttributedString {
     let monoFont = UIFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
     let result = NSMutableAttributedString()

--- a/apps/ios/Sources/Litter/Views/MessageBubbleView.swift
+++ b/apps/ios/Sources/Litter/Views/MessageBubbleView.swift
@@ -242,7 +242,6 @@ struct AssistantBubble: View, Equatable {
     let markdownIdentity: Int
     var label: String? = nil
     var compact: Bool = false
-    var themeVersion: Int = 0
     var allowsInlineSelection: Bool = true
     private let contentFontSize = LitterFont.conversationBodyPointSize
 
@@ -250,14 +249,12 @@ struct AssistantBubble: View, Equatable {
         text: String,
         label: String? = nil,
         compact: Bool = false,
-        themeVersion: Int = 0,
         allowsInlineSelection: Bool = true
     ) {
         self.markdownString = text
         self.markdownIdentity = text.hashValue
         self.label = label
         self.compact = compact
-        self.themeVersion = themeVersion
         self.allowsInlineSelection = allowsInlineSelection
     }
 
@@ -266,14 +263,12 @@ struct AssistantBubble: View, Equatable {
         markdownIdentity: Int,
         label: String? = nil,
         compact: Bool = false,
-        themeVersion: Int = 0,
         allowsInlineSelection: Bool = true
     ) {
         self.markdownString = markdownString
         self.markdownIdentity = markdownIdentity
         self.label = label
         self.compact = compact
-        self.themeVersion = themeVersion
         self.allowsInlineSelection = allowsInlineSelection
     }
 
@@ -281,7 +276,6 @@ struct AssistantBubble: View, Equatable {
         lhs.markdownIdentity == rhs.markdownIdentity &&
         lhs.label == rhs.label &&
         lhs.compact == rhs.compact &&
-        lhs.themeVersion == rhs.themeVersion &&
         lhs.allowsInlineSelection == rhs.allowsInlineSelection
     }
 
@@ -419,7 +413,6 @@ struct StreamingAssistantBubble: View {
     let text: String
     var isStreaming: Bool = false
     var label: String? = nil
-    var themeVersion: Int = 0
     var onSnapshotRendered: (() -> Void)? = nil
     private let contentFontSize: CGFloat
 
@@ -434,7 +427,6 @@ struct StreamingAssistantBubble: View {
         text: String,
         isStreaming: Bool = false,
         label: String? = nil,
-        themeVersion: Int = 0,
         bodySize: CGFloat = LitterFont.conversationBodyPointSize,
         onSnapshotRendered: (() -> Void)? = nil
     ) {
@@ -442,7 +434,6 @@ struct StreamingAssistantBubble: View {
         self.text = text
         self.isStreaming = isStreaming
         self.label = label
-        self.themeVersion = themeVersion
         self.contentFontSize = bodySize
         self.onSnapshotRendered = onSnapshotRendered
 
@@ -692,7 +683,6 @@ struct LitterCodeBlockRenderer: CodeBlockRenderer {
                 ScrollView(.horizontal, showsIndicators: false) {
                     SyntaxHighlightedDiffText(
                         diff: configuration.code,
-                        titleHint: configuration.language,
                         fontSize: LitterFont.conversationDiffPointSize
                     )
                     .padding(configuration.theme.codeBlock.padding)
@@ -738,8 +728,94 @@ private struct CodeBlockTerminalContextMenu: ViewModifier {
 
 // MARK: - Syntax Highlighting Theme Mapping
 
+/// Memoizes Highlightr's JS-based code tokenization.
+///
+/// `HighlightrCodeSyntaxHighlighter.highlightCode` runs highlight.js through
+/// JavaScriptCore — a synchronous, main-thread expensive call that also bakes
+/// the current theme's token colors into the result. HairballUI's
+/// `CodeBlockBody` calls it inline in `body`, so without memoization the same
+/// block is re-tokenized on every SwiftUI re-evaluation (streaming deltas,
+/// snapshot updates, scroll layout passes, theme changes).
+///
+/// The cache is keyed on the full render inputs — `(code, language, themeName)`
+/// — the same "compute once per inputs, reuse until they change" pattern the
+/// app already uses for diff rendering (`SyntaxHighlightedDiffText`). Because
+/// most Litter themes map to a shared Highlightr palette (e.g. the whole
+/// "atom-one-dark" family), switching between those themes does not change
+/// `themeName`, so the cached tokenization survives the switch and code blocks
+/// simply recolor through the theme environment instead of re-running the JS
+/// tokenizer.
+private final class CachedHighlightrCodeSyntaxHighlighter: CodeSyntaxHighlighter {
+    private struct Key: Hashable {
+        let code: String
+        let language: String?
+        let themeName: String
+    }
+
+    private let inner: HighlightrCodeSyntaxHighlighter
+    private let lock = NSLock()
+    private var cache: [Key: AttributedString] = [:]
+    private var insertionOrder: [Key] = []
+
+    private static let maxEntries = 256
+
+    init(theme: String) {
+        self.inner = HighlightrCodeSyntaxHighlighter(theme: theme)
+    }
+
+    var themeName: String {
+        inner.themeName
+    }
+
+    @discardableResult
+    func setTheme(_ name: String) -> Bool {
+        inner.setTheme(name)
+    }
+
+    func highlightCode(_ code: String, language: String?) -> AttributedString {
+        let key = Key(code: code, language: language, themeName: inner.themeName)
+
+        lock.lock()
+        if let hit = cache[key] {
+            touchLocked(key)
+            lock.unlock()
+            return hit
+        }
+        lock.unlock()
+
+        let result = inner.highlightCode(code, language: language)
+
+        lock.lock()
+        // Guard against caching a result colored by a theme that changed while
+        // the JS call was in flight (all current callers are main-thread, so
+        // this is defensive).
+        if cache[key] == nil && inner.themeName == key.themeName {
+            cache[key] = result
+            insertionOrder.append(key)
+            trimIfNeededLocked()
+        }
+        lock.unlock()
+        return result
+    }
+
+    private func touchLocked(_ key: Key) {
+        if let index = insertionOrder.firstIndex(of: key) {
+            insertionOrder.remove(at: index)
+        }
+        insertionOrder.append(key)
+    }
+
+    private func trimIfNeededLocked() {
+        guard cache.count > Self.maxEntries else { return }
+        while cache.count > Self.maxEntries * 3 / 4, let oldest = insertionOrder.first {
+            insertionOrder.removeFirst()
+            cache.removeValue(forKey: oldest)
+        }
+    }
+}
+
 /// Shared highlighter instance — theme is switched at runtime via `setTheme(_:)`.
-private let sharedHighlighter = HighlightrCodeSyntaxHighlighter(theme: "atom-one-dark")
+private let sharedHighlighter = CachedHighlightrCodeSyntaxHighlighter(theme: "atom-one-dark")
 
 /// Maps a Litter theme slug to the closest Highlightr theme name.
 /// Direct matches are checked first, then known family prefixes, then light/dark fallback.

--- a/apps/ios/Sources/Litter/Views/ToolCallCardView.swift
+++ b/apps/ios/Sources/Litter/Views/ToolCallCardView.swift
@@ -331,7 +331,6 @@ struct ToolCallCardView: View {
                 ScrollView(.horizontal, showsIndicators: true) {
                     SyntaxHighlightedDiffText(
                         diff: visibleText(content, id: id),
-                        titleHint: label.isEmpty ? nil : label,
                         fontSize: terminalFontSize
                     )
                     .padding(.horizontal, 10)


### PR DESCRIPTION
## Summary

Theme switching on iOS took **2+ seconds**; it is now **perceptually instant**, matching Android's theme-switch speed.

## Root cause

1. **JS code re-tokenization on every re-render.** Code-block syntax highlighting runs highlight.js through JavaScriptCore (`HighlightrCodeSyntaxHighlighter.highlightCode`) synchronously in the view body. Without memoization, every SwiftUI re-evaluation — streaming deltas, scroll, layout passes, and every theme switch — re-tokenized every visible code block on the main thread. For a code-heavy conversation this alone was multi-second.
2. **Theme forced through identity.** `themeManager.themeVersion` was threaded into `.id(...)` modifiers and bubble `Equatable` props, tearing down and rebuilding view subtrees on every theme change instead of recoloring in place.

## Changes

- **Memoized Highlightr tokenization** (`MessageBubbleView.swift`): a bounded LRU keyed on `(code, language, themeName)`. Because most Litter themes share one Highlightr palette (e.g. the whole "atom-one-dark" family), switching between same-family themes now hits the cache and simply recolors through the `@Observable ThemeStore` — no JS work at all. Light↔dark re-tokenizes each visible block exactly once. Also eliminates repeated JS during streaming/scroll.
- **Diff renderer self-updates on theme change** (`DiffRendering.swift`): `SyntaxHighlightedDiffText` now keys its `.task(id:)` render inputs on the resolved theme slug, so diffs re-render on theme change without the `.id(themeVersion)` teardown.
- **Removed theme identity churn**: dropped the `.id(themeManager.themeVersion)` teardowns (settings preview, diff sheet, navigation root) and the dead `themeVersion` props/`Equatable` usage in the bubbles. `ThemeStore` is `@Observable`, so views that read `LitterTheme.*` recolor directly — the same pattern Android uses with Compose snapshot state.
- **Dead code cleanup**: removed the now-unused `themeVersion` counter and the unused `titleHint`/`colorScheme` params in diff rendering.

## Verification

- Built with the fast simulator lane and switched themes on device: dark↔dark and dark↔light theme changes are perceptually instant (previously 2+ seconds with a visible stall on the open conversation).
- `Time Profiler` confirms the highlight.js tokenization is no longer hit on the main thread during a theme switch; code blocks are served from the memoization cache.

## Notes

- No behavior change: same Highlightr palettes, same theme mapping, same colors — just cached and recolored instead of re-tokenized.
- Follow-up idea: replace Highlightr with a tokenizer decoupled from coloring (like Android's Prism4j with a fixed palette) to also make light↔dark transitions zero-tokenization.

Closes #318
