### PR TITLE
feat(ios): keep the attach button available while a turn is running

### DIFF
--- a/apps/ios/Sources/Litter/Views/ConversationComposerEntryRowView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerEntryRowView.swift
@@ -175,7 +175,7 @@ struct ConversationComposerEntryRowView: View {
 
     private var actionRow: some View {
         HStack(spacing: 6) {
-            if !voiceManager.isRecording && !voiceManager.isTranscribing && !isTurnActive {
+            if !voiceManager.isRecording && !voiceManager.isTranscribing {
                 composerCircleButton(systemName: "plus", label: "Attach") {
                     showAttachMenu = true
                 }


### PR DESCRIPTION
Keeps the attach button enabled while a turn is streaming, so you can steer a running response with an image + text mid-run. One-line change: the button was gated on the same flag that disables send, but attachments queue into the composer and only ship when you actually send a steer message - there was no reason to lock it.

## Demo

https://github.com/user-attachments/assets/96c4566b-4ea7-44db-8bce-50fb4f30f780

Demo: stream running, attach sheet opened mid-run, orange swatch + steer text sent, model weaves the image into the in-flight response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
