### PR TITLE
feat(ios): highlight recognized skill mentions in the composer

### DIFF
--- a/apps/ios/Sources/Litter/Views/ConversationComposerTextView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerTextView.swift
@@ -1,6 +1,37 @@
 import SwiftUI
 import UIKit
 
+enum SkillMentionTokens {
+    static let namePattern = "[A-Za-z0-9_-]+"
+    private static let regex = try? NSRegularExpression(
+        pattern: "(?<![A-Za-z0-9_-])\\$(\(namePattern))"
+    )
+
+    static func matches(in text: String) -> [(name: String, range: NSRange)] {
+        guard let regex, !text.isEmpty else { return [] }
+        let fullRange = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.matches(in: text, range: fullRange).compactMap { match in
+            guard let nameRange = Range(match.range(at: 1), in: text) else { return nil }
+            return (String(text[nameRange]), match.range)
+        }
+    }
+
+    static func names(in text: String) -> [String] {
+        matches(in: text).map(\.name)
+    }
+}
+
+private struct SkillMentionHighlightNamesKey: EnvironmentKey {
+    static let defaultValue: Set<String> = []
+}
+
+extension EnvironmentValues {
+    var skillMentionHighlightNames: Set<String> {
+        get { self[SkillMentionHighlightNamesKey.self] }
+        set { self[SkillMentionHighlightNamesKey.self] = newValue }
+    }
+}
+
 /// Holds the composer's UIKit selection range *outside* SwiftUI state.
 ///
 /// The range is pure edit plumbing: nothing draws it. Its only readers are the
@@ -33,6 +64,7 @@ final class ComposerSelectionBox {
 }
 
 struct ConversationComposerTextView: UIViewRepresentable {
+    @Environment(\.skillMentionHighlightNames) var mentionHighlightNames
     @Binding var text: String
     @Binding var isFocused: Bool
     @Binding var selectedRange: NSRange
@@ -131,6 +163,8 @@ struct ConversationComposerTextView: UIViewRepresentable {
             uiView.text = text
             context.coordinator.applySelectedRange(to: uiView)
             context.coordinator.isSynchronizingText = false
+            context.coordinator.invalidateMentionHighlight()
+            context.coordinator.applyMentionHighlight(to: uiView)
         } else if !uiView.isFirstResponder {
             context.coordinator.applySelectedRange(to: uiView)
         }
@@ -191,6 +225,7 @@ struct ConversationComposerTextView: UIViewRepresentable {
                 parent.text = updatedText
             }
             updateSelectedRange(from: textView)
+            applyMentionHighlight(to: textView)
             // While focused the view is already scroll-enabled. Avoid forcing
             // TextKit to measure the entire draft again for every keystroke.
             if !textView.isFirstResponder {
@@ -239,6 +274,39 @@ struct ConversationComposerTextView: UIViewRepresentable {
             if textView.textColor != color {
                 textView.textColor = color
             }
+            applyMentionHighlight(to: textView)
+        }
+
+        private var lastHighlightedText: String?
+        private var lastHighlightNames: Set<String> = []
+
+        func invalidateMentionHighlight() {
+            lastHighlightedText = nil
+        }
+
+        func applyMentionHighlight(to textView: UITextView) {
+            let names = parent.mentionHighlightNames
+            let text = textView.text ?? ""
+            if text == lastHighlightedText, names == lastHighlightNames { return }
+            lastHighlightedText = text
+            lastHighlightNames = names
+
+            let storage = textView.textStorage
+            let fullRange = NSRange(location: 0, length: storage.length)
+            let baseColor = UIColor(LitterTheme.textPrimary)
+            let accentColor = UIColor(LitterTheme.success)
+            storage.beginEditing()
+            storage.addAttribute(.foregroundColor, value: baseColor, range: fullRange)
+            if !names.isEmpty {
+                for token in SkillMentionTokens.matches(in: text)
+                where names.contains(token.name.lowercased()) {
+                    let clamped = NSIntersectionRange(token.range, fullRange)
+                    guard clamped.length > 0 else { continue }
+                    storage.addAttribute(.foregroundColor, value: accentColor, range: clamped)
+                }
+            }
+            storage.endEditing()
+            textView.typingAttributes[.foregroundColor] = baseColor
         }
 
         func updateScrollState(for textView: UITextView) {

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -1639,6 +1639,7 @@ private struct ConversationInputBar: View {
                 isComposerFocused: $isComposerFocused,
                 composerSelectionRange: composerSelection.binding
             )
+            .environment(\.skillMentionHighlightNames, recognizedSkillNames)
             .overlay(alignment: .bottom) {
                 ConversationComposerPopupOverlayView(
                     state: popupState,
@@ -2595,6 +2596,10 @@ private struct ConversationInputBar: View {
         }
     }
 
+    private var recognizedSkillNames: Set<String> {
+        Set(skills.map { $0.name.lowercased() })
+    }
+
     private var skillSuggestions: [SkillMetadata] {
         guard let token = activeDollarToken else { return [] }
         return filterSkillSuggestions(token.value)
@@ -2936,17 +2941,13 @@ private func fuzzyScore(candidate: String, query: String) -> Int? {
     return queryIndex == normalizedQuery.endIndex ? score : nil
 }
 
-private let kDollarSign: UInt8 = 0x24
-private let kUnderscore: UInt8 = 0x5F
-private let kHyphen: UInt8 = 0x2D
-
 private func isMentionNameByte(_ byte: UInt8) -> Bool {
     switch byte {
     case 0x61...0x7A, // a-z
         0x41...0x5A,  // A-Z
         0x30...0x39,  // 0-9
-        kUnderscore,
-        kHyphen:
+        0x5F,         // _
+        0x2D:         // -
         return true
     default:
         return false
@@ -2959,40 +2960,7 @@ private func isMentionQueryValid(_ query: String) -> Bool {
 }
 
 private func extractMentionNames(_ text: String) -> [String] {
-    let bytes = Array(text.utf8)
-    guard !bytes.isEmpty else { return [] }
-
-    var mentions: [String] = []
-    var index = 0
-    while index < bytes.count {
-        guard bytes[index] == kDollarSign else {
-            index += 1
-            continue
-        }
-
-        if index > 0, isMentionNameByte(bytes[index - 1]) {
-            index += 1
-            continue
-        }
-
-        let nameStart = index + 1
-        guard nameStart < bytes.count, isMentionNameByte(bytes[nameStart]) else {
-            index += 1
-            continue
-        }
-
-        var nameEnd = nameStart + 1
-        while nameEnd < bytes.count, isMentionNameByte(bytes[nameEnd]) {
-            nameEnd += 1
-        }
-
-        if let name = String(bytes: bytes[nameStart..<nameEnd], encoding: .utf8) {
-            mentions.append(name)
-        }
-        index = nameEnd
-    }
-
-    return mentions
+    SkillMentionTokens.names(in: text)
 }
 
 func currentPrefixedToken(


### PR DESCRIPTION
Highlights recognized `$skill` mentions in the composer text as you type, using the already-fetched skill list as the single source of truth for what counts as a real skill. Unrecognized `$word` stays plain text.

## Demo

https://github.com/user-attachments/assets/6aa7a473-054e-4105-b55d-d2f3eb9f4223

Demo: `$` opens the suggestion popup, filtering to `$cad`, tap inserts, mention renders highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
