### PR TITLE
release: update App Store notes for 2.1.0

### DIFF
--- a/apps/ios/fastlane/metadata/en-US/release_notes.txt
+++ b/apps/ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,6 +1,7 @@
-Local Studio sessions now stay visible, correctly labeled, and connected to the right runtime.
+Litter 2.1 is much faster and more dependable during long-running sessions.
 
-- Start every new Local Studio conversation through its built-in Pi runtime.
-- Keep newly synchronized sessions visible even when older sessions are pinned.
-- Resume and reconnect without sessions disappearing or changing into Codex sessions.
-- Show the correct connected status without asking Local Studio users to sign in to OpenAI.
+- Keep Local Studio, the composer, and the project and model pickers responsive while sessions load and turns stream.
+- Send up to four images in one message and select or copy assistant text.
+- Connect to Claude Code and opencode over SSH with the correct agent name and icon.
+- Load more conversation history at once and move through new and existing threads more reliably.
+- Fix conversation navigation, Android session-row taps, and timestamp layout.


### PR DESCRIPTION
Purpose: make the App Store 2.1.0 metadata match the already validated TestFlight build from main.

Changes:
- replace the stale 2.0 Local Studio release notes with the verified 2.1 performance, attachment, SSH runtime, history, and navigation changes

Verification:
- `asc migrate validate --fastlane-dir apps/ios/fastlane --output json` (`valid: true`, zero errors/warnings)
- TestFlight 2.1.0 build 200000261 is processed and VALID in App Store Connect