### PR TITLE
ios: decode home cat WebPs off main [skip mobile-release]

### DIFF
--- a/apps/ios/Sources/Litter/Views/HomeSessionsScrollView.swift
+++ b/apps/ios/Sources/Litter/Views/HomeSessionsScrollView.swift
@@ -1027,6 +1027,150 @@ private struct HomeCatFooterView: View {
     }
 }
 
+/// Immutable, fully decoded frames that are safe to hand from the decoder
+/// task to the main actor. `CGImage` is immutable, and every frame has been
+/// rendered into its own bitmap before it enters this value.
+private struct AlphaAnimation: @unchecked Sendable {
+    let frames: [CGImage]
+    /// Cumulative end-time for each frame (frameEndTimes[i] is the
+    /// timestamp at which frame i finishes / frame i+1 begins).
+    let frameEndTimes: [TimeInterval]
+    let duration: TimeInterval
+
+    var cacheCost: Int {
+        frames.reduce(into: 0) { cost, frame in
+            cost += frame.bytesPerRow * frame.height
+        }
+    }
+}
+
+private final class AlphaAnimationBox: NSObject {
+    let animation: AlphaAnimation
+
+    init(_ animation: AlphaAnimation) {
+        self.animation = animation
+    }
+}
+
+private final class AlphaAnimationLoad {
+    let task: Task<AlphaAnimation, Never>
+
+    init(task: Task<AlphaAnimation, Never>) {
+        self.task = task
+    }
+}
+
+/// Keeps at most the two home-cat animations warm while allowing `NSCache`
+/// to discard them under memory pressure. The actor also ensures simultaneous
+/// views requesting the same URL share a single background decode.
+private actor AlphaAnimationCache {
+    static let shared = AlphaAnimationCache()
+
+    private let cache: NSCache<NSURL, AlphaAnimationBox> = {
+        let cache = NSCache<NSURL, AlphaAnimationBox>()
+        cache.countLimit = 2
+        cache.totalCostLimit = 96 * 1024 * 1024
+        return cache
+    }()
+    private var inFlight: [URL: AlphaAnimationLoad] = [:]
+
+    func animation(for url: URL) async -> AlphaAnimation {
+        let key = url as NSURL
+        if let cached = cache.object(forKey: key) {
+            return cached.animation
+        }
+
+        let load: AlphaAnimationLoad
+        if let existing = inFlight[url] {
+            load = existing
+        } else {
+            load = AlphaAnimationLoad(
+                task: Task.detached(priority: .userInitiated) {
+                    decodeAlphaAnimation(from: url)
+                }
+            )
+            inFlight[url] = load
+        }
+
+        let animation = await load.task.value
+        if inFlight[url] === load {
+            inFlight[url] = nil
+        }
+        if !animation.frames.isEmpty {
+            cache.setObject(
+                AlphaAnimationBox(animation),
+                forKey: key,
+                cost: animation.cacheCost
+            )
+        }
+        return animation
+    }
+}
+
+/// Forces ImageIO's lazily-created frame into a standalone bitmap. This runs
+/// only in `AlphaAnimationCache`'s detached task, never on the main actor.
+private func decodeAlphaAnimation(from url: URL) -> AlphaAnimation {
+    autoreleasepool {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+            return AlphaAnimation(frames: [], frameEndTimes: [], duration: 0)
+        }
+
+        let count = CGImageSourceGetCount(source)
+        let imageOptions = [kCGImageSourceShouldCacheImmediately: true] as CFDictionary
+        var frames: [CGImage] = []
+        var ends: [TimeInterval] = []
+        frames.reserveCapacity(count)
+        ends.reserveCapacity(count)
+        var cumulative: TimeInterval = 0
+
+        for index in 0..<count {
+            autoreleasepool {
+                guard let sourceImage = CGImageSourceCreateImageAtIndex(source, index, imageOptions),
+                      let decodedImage = forceDecodedAlphaFrame(sourceImage)
+                else { return }
+
+                frames.append(decodedImage)
+                cumulative += alphaAnimationPlaybackFrameDuration
+                ends.append(cumulative)
+            }
+        }
+
+        return AlphaAnimation(
+            frames: frames,
+            frameEndTimes: ends,
+            duration: max(cumulative, 0.1)
+        )
+    }
+}
+
+private func forceDecodedAlphaFrame(_ image: CGImage) -> CGImage? {
+    let width = image.width
+    let height = image.height
+    guard width > 0, height > 0 else { return nil }
+
+    guard let context = CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ) else { return nil }
+
+    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+    return context.makeImage()
+}
+
+/// Our iOS APNGs were authored at 10fps (100ms per frame), but the
+/// equivalent Android WebPs render at 15fps (67ms per frame) — so
+/// the same 165-frame entrance runs 16.5s on iOS vs 11.055s on
+/// Android. Force playback at the Android cadence by overriding
+/// the encoded delays. The source frames are uniform in both
+/// files, so a flat per-frame duration here is exact, not a
+/// resampling approximation.
+private let alphaAnimationPlaybackFrameDuration: TimeInterval = 1.0 / 15.0
+
 struct AlphaAnimatedImageView: UIViewRepresentable {
     let fileURL: URL
     var repeatCount: Int = 0
@@ -1065,12 +1209,16 @@ struct AlphaAnimatedImageView: UIViewRepresentable {
         Coordinator()
     }
 
+    @MainActor
     final class Coordinator: NSObject, CAAnimationDelegate {
         private var configuredURL: URL?
         private var configuredRepeatCount: Int?
         private var onFinished: (() -> Void)?
         private weak var imageView: UIImageView?
         private var finishedFired = false
+        private var configurationGeneration: UInt64 = 0
+        private var isStopped = false
+        private var loadTask: Task<Void, Never>?
 
         // Frames are swapped via `CAKeyframeAnimation` on
         // `layer.contents` in `.discrete` mode. Core Animation runs
@@ -1079,6 +1227,7 @@ struct AlphaAnimatedImageView: UIViewRepresentable {
         // per-frame delays — no main-thread/display-link aliasing,
         // and no flat tempo from UIImageView's animationImages.
         private static let animationKey = "alphaFrames"
+        private static let animationGenerationKey = "alphaFrames.generation"
 
         func configure(
             _ imageView: UIImageView,
@@ -1088,16 +1237,50 @@ struct AlphaAnimatedImageView: UIViewRepresentable {
         ) {
             self.onFinished = onFinished
             self.imageView = imageView
-            guard configuredURL != fileURL || configuredRepeatCount != repeatCount else { return }
+            let needsLoad = configuredURL != fileURL
+                || configuredRepeatCount != repeatCount
+                || isStopped
+            guard needsLoad else { return }
+
             configuredURL = fileURL
             configuredRepeatCount = repeatCount
             finishedFired = false
+            isStopped = false
+            configurationGeneration &+= 1
+            let generation = configurationGeneration
+            loadTask?.cancel()
+            loadTask = nil
 
             imageView.animationImages = nil
             imageView.stopAnimating()
             imageView.layer.removeAnimation(forKey: Coordinator.animationKey)
 
-            let animation = AlphaAnimatedImageView.animation(from: fileURL)
+            loadTask = Task { @MainActor [weak self] in
+                let animation = await AlphaAnimationCache.shared.animation(for: fileURL)
+                guard !Task.isCancelled, let self else { return }
+                self.install(
+                    animation,
+                    fileURL: fileURL,
+                    repeatCount: repeatCount,
+                    generation: generation
+                )
+            }
+        }
+
+        private func install(
+            _ animation: AlphaAnimation,
+            fileURL: URL,
+            repeatCount: Int,
+            generation: UInt64
+        ) {
+            guard !isStopped,
+                  generation == configurationGeneration,
+                  configuredURL == fileURL,
+                  configuredRepeatCount == repeatCount,
+                  let imageView
+            else { return }
+
+            loadTask = nil
             guard let first = animation.frames.first else {
                 imageView.image = nil
                 return
@@ -1131,60 +1314,41 @@ struct AlphaAnimatedImageView: UIViewRepresentable {
             keyAnim.fillMode = .forwards
             keyAnim.isRemovedOnCompletion = false
             keyAnim.delegate = self
+            keyAnim.setValue(
+                NSNumber(value: generation),
+                forKey: Coordinator.animationGenerationKey
+            )
 
             imageView.layer.add(keyAnim, forKey: Coordinator.animationKey)
         }
 
         func stop() {
+            configurationGeneration &+= 1
+            isStopped = true
+            loadTask?.cancel()
+            loadTask = nil
             imageView?.layer.removeAnimation(forKey: Coordinator.animationKey)
         }
 
-        func animationDidStop(_ anim: CAAnimation, finished: Bool) {
-            guard finished, !finishedFired else { return }
+        nonisolated func animationDidStop(_ anim: CAAnimation, finished: Bool) {
+            guard finished,
+                  let generation = (anim.value(forKey: "alphaFrames.generation") as? NSNumber)?.uint64Value
+            else { return }
+
+            Task { @MainActor [weak self] in
+                self?.finishAnimation(generation: generation)
+            }
+        }
+
+        private func finishAnimation(generation: UInt64) {
+            guard !finishedFired,
+                  generation == configurationGeneration,
+                  !isStopped
+            else { return }
             guard let repeats = configuredRepeatCount, repeats > 0 else { return }
             finishedFired = true
             onFinished?()
         }
-    }
-
-    private struct Animation {
-        let frames: [CGImage]
-        /// Cumulative end-time for each frame (frameEndTimes[i] is the
-        /// timestamp at which frame i finishes / frame i+1 begins).
-        let frameEndTimes: [TimeInterval]
-        let duration: TimeInterval
-    }
-
-    /// Our iOS APNGs were authored at 10fps (100ms per frame), but the
-    /// equivalent Android WebPs render at 15fps (67ms per frame) — so
-    /// the same 165-frame entrance runs 16.5s on iOS vs 11.055s on
-    /// Android. Force playback at the Android cadence by overriding
-    /// the encoded delays. The source frames are uniform in both
-    /// files, so a flat per-frame duration here is exact, not a
-    /// resampling approximation.
-    private static let playbackFrameDuration: TimeInterval = 1.0 / 15.0
-
-    private static func animation(from url: URL) -> Animation {
-        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
-            return Animation(frames: [], frameEndTimes: [], duration: 0)
-        }
-        let count = CGImageSourceGetCount(source)
-        var frames: [CGImage] = []
-        var ends: [TimeInterval] = []
-        frames.reserveCapacity(count)
-        ends.reserveCapacity(count)
-        var cumulative: TimeInterval = 0
-        for index in 0..<count {
-            guard let cgImage = CGImageSourceCreateImageAtIndex(source, index, nil) else { continue }
-            frames.append(cgImage)
-            cumulative += playbackFrameDuration
-            ends.append(cumulative)
-        }
-        return Animation(
-            frames: frames,
-            frameEndTimes: ends,
-            duration: max(cumulative, 0.1)
-        )
     }
 
 }


### PR DESCRIPTION
## Purpose

Fixes #333.

Keep iOS startup and Home navigation responsive while the bundled home-cat WebPs are expanded. The visual behavior remains the same: the entrance plays once, then hands off to the infinite loop.

## Root cause

`AlphaAnimatedImageView.Coordinator.configure` synchronously decoded every ImageIO frame on the main actor. The entrance and loop contain 165 and 120 frames respectively, totaling about 79.3 MiB as decoded RGBA bitmaps. A cold-start stack sample found all 38 main-thread samples inside the first Core Animation commit through ImageIO and `WebPReadPlugin`.

## Changes

- Decode and force-realize each frame in a detached user-initiated task.
- Coalesce concurrent loads for the same URL in an actor.
- Hold the two decoded animations in an evictable `NSCache`, bounded to 96 MiB.
- Keep all `UIImageView` and Core Animation installation on the main actor.
- Cancel superseded view tasks and use generation tags to reject stale installs or completion callbacks.
- Preserve the existing 15 fps cadence, finite entrance completion, and infinite loop behavior.

The cache intentionally permits both bundled animations (~79.3 MiB decoded) so returning Home does not repeat the expansion. `NSCache` may evict either entry under memory pressure.

## Platform scope

This is an iOS-specific ImageIO/UIKit defect. Android uses its own native animated-WebP renderer, so no Android behavior or shared runtime state changes.

## Verification

| Path | Before | After |
|---|---:|---:|
| Cold UI readiness | ~14 s | ~0.585 s |
| Search to Home readiness | Still blank after 8.4 s | ~1.174 s |

- Swift 5 targeted and Swift 6 complete focused iOS typechecks passed.
- Swift 6 complete Mac Catalyst typecheck passed.
- Generic arm64 Simulator build passed; the fixed app was installed and exercised in Simulator.
- Release arm64 iPhone target build passed.
- Off-main smoke decode returned all 165 entrance and 120 loop frames.
- Follow-up sampling found the main thread idle in 35/37 samples, with no ImageIO/WebP work on it.
- Screenshots taken after the entrance duration confirmed that the loop continued advancing.
- `git diff --check` passed.

No screenshot is attached because this is a scheduling/performance fix with no intended visual change.
